### PR TITLE
Add draggable gradient color picker with synchronized color values

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,28 +298,32 @@
             <button type="button" class="window-secondary-button">Add to Custom Colors</button>
           </div>
 
-          <div class="color-right-panel" aria-hidden="true">
+          <div class="color-right-panel">
             <div class="color-map-row">
-              <div class="color-map"></div>
-              <div class="color-slider"></div>
+              <div class="color-map" id="color-map" role="slider" aria-label="Saturation and value" tabindex="0">
+                <div class="color-map-handle" id="color-map-handle" aria-hidden="true"></div>
+              </div>
+              <div class="color-slider" id="color-slider" role="slider" aria-label="Hue" tabindex="0">
+                <div class="color-slider-handle" id="color-slider-handle" aria-hidden="true"></div>
+              </div>
             </div>
             <div class="color-values-row">
-              <div class="selected-color-preview"></div>
+              <div class="selected-color-preview" id="selected-color-preview"></div>
               <div class="value-controls">
                 <div class="value-grid">
-                  <label>Hue: <input type="number" value="35" /></label>
-                  <label>Red: <input type="number" value="255" /></label>
-                  <label>Sat: <input type="number" value="232" /></label>
-                  <label>Green: <input type="number" value="158" /></label>
-                  <label>Val: <input type="number" value="255" /></label>
-                  <label>Blue: <input type="number" value="23" /></label>
+                  <label>Hue: <input type="number" id="color-value-hue" min="0" max="360" value="35" /></label>
+                  <label>Red: <input type="number" id="color-value-red" min="0" max="255" value="255" /></label>
+                  <label>Sat: <input type="number" id="color-value-sat" min="0" max="255" value="232" /></label>
+                  <label>Green: <input type="number" id="color-value-green" min="0" max="255" value="158" /></label>
+                  <label>Val: <input type="number" id="color-value-val" min="0" max="255" value="255" /></label>
+                  <label>Blue: <input type="number" id="color-value-blue" min="0" max="255" value="23" /></label>
                 </div>
-                <label class="html-value">HTML: <input type="text" value="#ff9e17" /></label>
+                <label class="html-value">HTML: <input type="text" id="color-value-hex" value="#ff9e17" /></label>
               </div>
             </div>
             <div class="dialog-action-row">
-              <button type="button" class="window-primary-button">OK</button>
-              <button type="button" class="window-secondary-button">Cancel</button>
+              <button type="button" class="window-primary-button" id="color-window-ok">OK</button>
+              <button type="button" class="window-secondary-button" id="color-window-cancel">Cancel</button>
             </div>
           </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -712,23 +712,39 @@ label {
   height: 200px;
   position: relative;
   border: 1px solid #2a2a2a;
+  cursor: crosshair;
   background:
     linear-gradient(to top, #ffffff, rgb(255 255 255 / 0%)),
     linear-gradient(to right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
 }
 
-.color-map::after {
-  content: '+';
+.color-map-handle {
   position: absolute;
-  right: 14px;
-  top: 8px;
-  font-size: 2rem;
-  color: #111;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 1px #111;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
 }
 
 .color-slider {
+  position: relative;
   border: 1px solid #2a2a2a;
-  background: linear-gradient(to bottom, #ff7f00, #222);
+  cursor: ns-resize;
+  background: linear-gradient(to bottom, #ff0000, #ff00ff, #0000ff, #00ffff, #00ff00, #ffff00, #ff0000);
+}
+
+.color-slider-handle {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: #fff;
+  box-shadow: 0 0 0 1px #111;
+  transform: translateY(-50%);
+  pointer-events: none;
 }
 
 .color-values-row {


### PR DESCRIPTION
### Motivation
- Provide an interactive color picker so users can choose colors by clicking or click-dragging the gradients and immediately see the result.
- Keep the color preview and numeric fields (Red, Green, Blue, Hue, Sat, Val, HTML) synchronized with the selected color so edits and picks remain consistent.

### Description
- Added markup IDs and controls in the color dialog (`index.html`) including `#color-map`, `#color-map-handle`, `#color-slider`, `#color-slider-handle`, `#selected-color-preview`, RGB/HSV/HEX inputs (`#color-value-*`) and `#color-window-ok`/`#color-window-cancel` buttons.
- Updated styles (`styles.css`) to render the saturation/value map and hue slider, show draggable handles, and use appropriate cursors and gradients for pointer interactions.
- Implemented a color picker subsystem in `script.js` that provides HSV↔RGB conversion, HEX parsing/formatting, a `colorPickerState`, `syncColorPickerUI()` to update preview and all inputs, and `updateMapFromPointer()` / `updateHueFromPointer()` to support click and drag on the gradients.
- Wired input listeners so changing HSV, RGB or HEX fields updates the picker, and connected the OK button to apply the chosen color to the Quill editor text color via `applyColorFromSwatch()`; the dialog initializes from the current editor color on open.

### Testing
- Ran `node --check script.js` to validate the modified JavaScript and it succeeded.
- Performed a manual browser verification using Playwright to open the dialog, simulate click/drag on the color map, and capture a screenshot which confirmed the preview and numeric fields updated as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ff77315c8326838cc935a0913fe2)