### PR TITLE
Shift custom color swatches when adding a new custom color

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
 
             <span class="panel-label custom-label">Custom colors</span>
             <div class="custom-colors-grid" aria-hidden="true"></div>
-            <button type="button" class="window-secondary-button">Add to Custom Colors</button>
+            <button type="button" class="window-secondary-button" id="add-custom-color">Add to Custom Colors</button>
           </div>
 
           <div class="color-right-panel">

--- a/script.js
+++ b/script.js
@@ -79,6 +79,7 @@ const colorWindowOverlay = document.getElementById('color-window-overlay');
 const closeColorWindowButton = document.getElementById('close-color-window');
 const basicColorsGrid = document.querySelector('.basic-colors-grid');
 const customColorsGrid = document.querySelector('.custom-colors-grid');
+const addCustomColorButton = document.getElementById('add-custom-color');
 
 const colorMap = document.getElementById('color-map');
 const colorMapHandle = document.getElementById('color-map-handle');
@@ -114,6 +115,14 @@ const basicColorPalette = [
   '#8000ff', '#ff0080', '#ff8000', '#80ff00', '#00ff80', '#0080ff', '#8000ff', '#ffe680',
   '#660033', '#cc3300', '#cc6600', '#66cc00', '#00cc66', '#0066cc', '#3300cc', '#66ffff',
 ];
+
+const customColorPalette = Array.from({ length: 16 }, () => '#f3f4f6');
+
+function handleAddCustomColor() {
+  customColorPalette.pop();
+  customColorPalette.unshift(colorPickerState.draftHex);
+  populateColorGrid(customColorsGrid, customColorPalette);
+}
 
 function setColorPickerFromHex(color) {
   if (!color) {
@@ -1561,7 +1570,11 @@ imageNameInput.addEventListener('keydown', (event) => {
 });
 
 populateColorGrid(basicColorsGrid, basicColorPalette);
-populateColorGrid(customColorsGrid, Array.from({ length: 16 }, () => '#f3f4f6'));
+populateColorGrid(customColorsGrid, customColorPalette);
+
+if (addCustomColorButton) {
+  addCustomColorButton.addEventListener('click', handleAddCustomColor);
+}
 
 if (testWindowButton) {
   testWindowButton.addEventListener('click', openColorWindow);


### PR DESCRIPTION
### Motivation
- Implement the requested behavior so clicking Add to Custom Colors shifts all custom swatches right with wrap from the top row to the bottom row and places the current picker color into the top-left slot.

### Description
- Added an `id` to the Add to Custom Colors button (`id="add-custom-color"`) so it can be targeted from script.
- Introduced a persistent `customColorPalette` array (`const customColorPalette = Array.from({ length: 16 }, () => '#f3f4f6')`) to back the 16 custom swatches instead of recreating them on each render.
- Implemented `handleAddCustomColor()` which does `customColorPalette.pop()` then `customColorPalette.unshift(colorPickerState.draftHex)` and re-renders via `populateColorGrid(customColorsGrid, customColorPalette)` to achieve the right-shift/wrap/drop behavior and place the picker color in the top-left swatch.
- Wired the new behavior by switching the initial render to use `customColorPalette` and attaching the click handler to the button (`addCustomColorButton.addEventListener('click', handleAddCustomColor)`).

### Testing
- Run-time syntax check with `node --check script.js` succeeded.
- Launched a local HTTP server with `python3 -m http.server 4173` and performed a UI verification via an automated Playwright script that opened the color window, picked a color, clicked Add to Custom Colors, and captured a screenshot; the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69910a7c68688326a532d8f8fa7393db)