### PR TITLE
Fix hue slider gradient order in color picker

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -733,7 +733,7 @@ label {
   position: relative;
   border: 1px solid #2a2a2a;
   cursor: ns-resize;
-  background: linear-gradient(to bottom, #ff0000, #ff00ff, #0000ff, #00ffff, #00ff00, #ffff00, #ff0000);
+  background: linear-gradient(to bottom, #ff0000, #ffff00, #00ff00, #00ffff, #0000ff, #ff00ff, #ff0000);
 }
 
 .color-slider-handle {


### PR DESCRIPTION
### Motivation
- Resolve a visual mismatch where the hue slider gradient did not follow the HSV hue progression used by the picker logic, causing the preview color to appear incorrect.

### Description
- Reordered the gradient stops for `.color-slider` in `styles.css` to follow the HSV sequence red → yellow → green → cyan → blue → magenta → red, aligning the slider visuals with the picker calculations.

### Testing
- Ran `git diff --check` which succeeded, hosted the app via `python3 -m http.server 4173` for verification, and attempted automated Playwright screenshots but the Chromium run crashed (SIGSEGV) and Firefox run failed (`NS_ERROR_NET_RESET`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69910ceecdc883268ddc158c88bf1b88)