### PR TITLE
Move color picker trigger into editor toolbar (add 🎨 toolbar button)

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
             <button class="ql-bold" type="button" aria-label="Bold"></button>
             <button class="ql-italic" type="button" aria-label="Italic"></button>
             <button class="ql-underline" type="button" aria-label="Underline"></button>
-            <select class="ql-color" aria-label="Text color"></select>
+            <button class="ql-open-color-window" type="button" aria-label="Open color picker">🎨</button>
             <button class="ql-align" value="" type="button" aria-label="Align left"></button>
             <button class="ql-align" value="center" type="button" aria-label="Align center"></button>
             <button class="ql-align" value="right" type="button" aria-label="Align right"></button>
@@ -48,7 +48,6 @@
             Wrap text
           </label>
 
-          <button type="button" id="open-color-window" class="test-window-button">Test</button>
 
           <section class="canvas-background-controls" aria-label="Canvas background options">
             <details class="option-accordion" aria-label="Canvas background color options">

--- a/script.js
+++ b/script.js
@@ -74,7 +74,6 @@ const sidePaddingControls = {
 };
 
 const wrapTextInput = document.getElementById('wrap-text');
-const testWindowButton = document.getElementById('open-color-window');
 const colorWindowOverlay = document.getElementById('color-window-overlay');
 const closeColorWindowButton = document.getElementById('close-color-window');
 const basicColorsGrid = document.querySelector('.basic-colors-grid');
@@ -430,6 +429,9 @@ const quill = new Quill('#editor', {
   modules: {
     toolbar: {
       container: '#editor-toolbar',
+      handlers: {
+        'open-color-window': openColorWindow,
+      },
     },
   },
   placeholder: 'Type formatted text here...',
@@ -1576,9 +1578,6 @@ if (addCustomColorButton) {
   addCustomColorButton.addEventListener('click', handleAddCustomColor);
 }
 
-if (testWindowButton) {
-  testWindowButton.addEventListener('click', openColorWindow);
-}
 
 if (closeColorWindowButton) {
   closeColorWindowButton.addEventListener('click', closeColorWindow);

--- a/styles.css
+++ b/styles.css
@@ -80,6 +80,16 @@ label {
   background: #f9fafb;
 }
 
+
+.ql-snow .ql-toolbar button.ql-open-color-window,
+.ql-snow.ql-toolbar button.ql-open-color-window {
+  width: 28px;
+  padding: 0;
+  font-size: 16px;
+  line-height: 1;
+}
+
+
 #editor {
   min-height: 260px;
   max-height: 33vh;
@@ -550,18 +560,6 @@ label {
   background: #1e40af;
 }
 
-
-
-.test-window-button {
-  align-self: flex-start;
-  padding: 0.45rem 0.9rem;
-  border: 1px solid #9ca3af;
-  border-radius: 6px;
-  background: linear-gradient(#f3f4f6, #d1d5db);
-  color: #111827;
-  font-weight: 600;
-  cursor: pointer;
-}
 
 .color-window-overlay.hidden {
   display: none;


### PR DESCRIPTION
### Motivation
- Simplify the editor UI by removing the separate text color selector and the standalone test button, and provide a single, discoverable toolbar control to open the custom color picker. 
- Make color selection feel native to the text formatting toolbar and reduce duplicated controls.

### Description
- Removed the `<select class="ql-color">` from the toolbar and deleted the standalone color-window button under the editor in `index.html`.
- Added a new toolbar button `button.ql-open-color-window` containing the 🎨 emoji to `index.html` so the picker is launched from the editor toolbar.
- Wired a Quill toolbar handler, adding `handlers: { 'open-color-window': openColorWindow }` to the Quill initialization in `script.js`, and removed the old DOM event hookup for the deleted test button.
- Added styling for `.ql-open-color-window` in `styles.css` and removed obsolete `.test-window-button` styles.

### Testing
- Ran `node --check script.js` to validate the JS syntax, which succeeded.
- Served the app locally with `python -m http.server 4173 --bind 0.0.0.0` and used Playwright to load `http://127.0.0.1:4173/index.html` for visual verification, which succeeded and produced a screenshot of the updated toolbar.
- Verified the color window still opens from the new toolbar button via the attached Quill handler during the visual test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699111e8d9a88326b41bf7470fb9ea3a)