### PR TITLE
Add screen-wide eyedropper support in Select Color dialog and bump version

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,7 +288,7 @@
           <div class="color-left-panel">
             <span class="panel-label">Basic colors</span>
             <div class="basic-colors-grid" aria-hidden="true"></div>
-            <button type="button" class="window-secondary-button pick-screen-color-button" aria-label="Pick Screen Color">
+            <button type="button" id="pick-screen-color" class="window-secondary-button pick-screen-color-button" aria-label="Pick Screen Color">
               <img src="assets/icons/eye-dropper.png" alt="Pick Screen Color" class="pick-screen-color-icon" />
             </button>
 


### PR DESCRIPTION
### Motivation
- Allow users to pick a color from anywhere on the screen from the Select Color dialog to improve color selection accuracy.
- Expose a clear UI target for the eyedropper so it can be wired from JavaScript.

### Description
- Added an `id="pick-screen-color"` to the eyedropper button in `index.html` so it can be targeted from script code.
- Implemented `pickColorFromScreen()` in `script.js` that uses the browser `EyeDropper` API to sample a color, updates the color picker with the sampled hex, and guards concurrent sessions with `colorPickerState.isPickingFromScreen`.
- Wired the new `pickScreenColorButton` to call the picker and disabled the button while a pick is in progress, and re-enabled it after completion or cancellation.
- Added a graceful fallback for unsupported browsers by disabling the eyedropper button and adding a tooltip when `window.EyeDropper` is not available.
- Incremented the in-app version constant from `v1.1.3` to `v1.1.4`.

### Testing
- Performed a syntax check with `node --check script.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991514b56208326b55150e3d6c52f7c)