### PR TITLE
Add quill-image-resize integration for Quill editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,6 +333,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/quill-image-resize-module@3.0.0/image-resize.min.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -429,6 +429,10 @@ const QuillFont = Quill.import('formats/font');
 QuillFont.whitelist = FONT_WHITELIST;
 Quill.register(QuillFont, true);
 
+if (window.ImageResize) {
+  Quill.register('modules/imageResize', window.ImageResize);
+}
+
 const FONT_MAP = {
   sansserif: 'Arial, Helvetica, sans-serif',
   serif: 'Georgia, "Times New Roman", serif',
@@ -461,6 +465,7 @@ const quill = new Quill('#editor', {
         'open-color-window': openColorWindow,
       },
     },
+    imageResize: {},
   },
   placeholder: 'Type formatted text here...',
 });


### PR DESCRIPTION
### Motivation
- Enable in-editor resizing of images inserted into the Quill rich text editor so users can adjust images before exporting the canvas. 
- No Codex skills were used for this change.

### Description
- Added the `quill-image-resize-module@3.0.0` CDN script to `index.html` so the plugin is available on page load. 
- Registered the module in `script.js` when `window.ImageResize` is present via `Quill.register('modules/imageResize', window.ImageResize)`. 
- Enabled the module in the Quill configuration by adding `imageResize: {}` to the `modules` object in the `new Quill(...)` call.

### Testing
- Started a local static server with `python -m http.server 4173` and loaded the app in Playwright, capturing a screenshot successfully. 
- Verified the source changes with `git diff` and `git status` and committed the modifications to `index.html` and `script.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e6d388b48326903809c4f78ba08d)