### PR TITLE
Show checkerboard in transparent canvas preview

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -39,7 +39,12 @@ body {
 #preview-canvas {
   display: block;
   margin: auto;
-  background: #ffffff;
+  background-color: #d1d5db;
+  background-image:
+    linear-gradient(45deg, #e5e7eb 25%, transparent 25%, transparent 75%, #e5e7eb 75%, #e5e7eb),
+    linear-gradient(45deg, #e5e7eb 25%, transparent 25%, transparent 75%, #e5e7eb 75%, #e5e7eb);
+  background-position: 0 0, 8px 8px;
+  background-size: 16px 16px;
   box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
 }
 


### PR DESCRIPTION
### Motivation
- Provide a visual checkerboard behind transparent canvas areas in the editor preview so users can easily see transparency without changing exported image transparency.

### Description
- Updated `#preview-canvas` in `styles.css` to add `background-color` and two layered `linear-gradient` backgrounds with `background-position` and `background-size` to render a tiled light/dark gray checkerboard in the on-screen preview, with no changes to JavaScript rendering or export logic.

### Testing
- Automated checks included starting a local HTTP server, capturing a Playwright screenshot saved as `artifacts/canvas-transparency-checkerboard.png` to verify the preview, and committing the change with `git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69935af4061c8326ae56e2d16284b4d3)