### PR TITLE
Add table-driven unit tests for color conversion helpers

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -88,6 +88,10 @@ export function rgbToHex(red, green, blue) {
 }
 
 export function hexToRgb(hex) {
+  if (typeof hex !== 'string') {
+    return null;
+  }
+
   const normalized = hex.trim().replace(/^#/, '');
 
   if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {

--- a/tests/unit/color.test.js
+++ b/tests/unit/color.test.js
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import { clampNumber, hexToRgb, hsvToRgb, rgbToHsv } from '../../src/color.js';
+
+describe('color conversion utilities', () => {
+  it.each([
+    {
+      name: 'orange keeps stable round-trip values',
+      input: { red: 255, green: 165, blue: 0 },
+      expectedHsv: { hue: 39, sat: 255, val: 255 },
+      expectedRoundTrip: { red: 255, green: 166, blue: 0 },
+    },
+    {
+      name: 'steel blue keeps stable round-trip values',
+      input: { red: 70, green: 130, blue: 180 },
+      expectedHsv: { hue: 207, sat: 156, val: 180 },
+      expectedRoundTrip: { red: 70, green: 130, blue: 180 },
+    },
+    {
+      name: 'low-intensity blue keeps stable round-trip values',
+      input: { red: 12, green: 34, blue: 56 },
+      expectedHsv: { hue: 210, sat: 200, val: 56 },
+      expectedRoundTrip: { red: 12, green: 34, blue: 56 },
+    },
+    {
+      name: 'muted purple keeps stable round-trip values',
+      input: { red: 123, green: 120, blue: 125 },
+      expectedHsv: { hue: 276, sat: 10, val: 125 },
+      expectedRoundTrip: { red: 123, green: 120, blue: 125 },
+    },
+  ])('$name', ({ input, expectedHsv, expectedRoundTrip }) => {
+    const hsv = rgbToHsv(input.red, input.green, input.blue);
+    expect(hsv).toEqual(expectedHsv);
+
+    const roundTrip = hsvToRgb(hsv.hue, hsv.sat, hsv.val);
+    expect(roundTrip).toEqual(expectedRoundTrip);
+  });
+
+  it.each([
+    {
+      name: 'black',
+      rgb: { red: 0, green: 0, blue: 0 },
+      hsv: { hue: 0, sat: 0, val: 0 },
+    },
+    {
+      name: 'white',
+      rgb: { red: 255, green: 255, blue: 255 },
+      hsv: { hue: 0, sat: 0, val: 255 },
+    },
+    {
+      name: 'red primary',
+      rgb: { red: 255, green: 0, blue: 0 },
+      hsv: { hue: 0, sat: 255, val: 255 },
+    },
+    {
+      name: 'green primary',
+      rgb: { red: 0, green: 255, blue: 0 },
+      hsv: { hue: 120, sat: 255, val: 255 },
+    },
+    {
+      name: 'blue primary',
+      rgb: { red: 0, green: 0, blue: 255 },
+      hsv: { hue: 240, sat: 255, val: 255 },
+    },
+  ])('edge bounds for $name', ({ rgb, hsv }) => {
+    expect(rgbToHsv(rgb.red, rgb.green, rgb.blue)).toEqual(hsv);
+    expect(hsvToRgb(hsv.hue, hsv.sat, hsv.val)).toEqual(rgb);
+  });
+});
+
+describe('hexToRgb', () => {
+  it.each([
+    { name: 'null value', input: null, expected: null },
+    { name: 'short value', input: '#abc', expected: null },
+    { name: 'invalid characters', input: '#12GG55', expected: null },
+  ])('returns null for $name', ({ input, expected }) => {
+    expect(hexToRgb(input)).toBe(expected);
+  });
+});
+
+describe('clampNumber', () => {
+  it.each([
+    {
+      name: 'NaN input uses fallback',
+      args: [Number.NaN, 0, 255, 12],
+      expected: 12,
+    },
+    {
+      name: 'negative value clamps to min',
+      args: [-10, 0, 255, 99],
+      expected: 0,
+    },
+    {
+      name: 'value over max clamps to max',
+      args: [999, 0, 255, 99],
+      expected: 255,
+    },
+    {
+      name: 'non-numeric string uses fallback',
+      args: ['not-a-number', 0, 255, 77],
+      expected: 77,
+    },
+  ])('$name', ({ args, expected }) => {
+    expect(clampNumber(...args)).toBe(expected);
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve coverage for the color utilities by exercising RGB↔HSV round-trip behavior for representative colors and verifying edge bounds for black/white/primary colors.
- Validate error and boundary handling for `hexToRgb` and `clampNumber` to prevent runtime surprises from invalid inputs.

### Description
- Add `tests/unit/color.test.js` with table-driven `it.each` cases that assert RGB → HSV expected values and HSV → RGB round-trip results for several representative colors.
- Add table-driven edge-bound tests for black, white, and primary red/green/blue to assert both `rgbToHsv` and `hsvToRgb` behavior.
- Add table-driven invalid-input tests for `hexToRgb` (covering `null`, short form like `#abc`, and invalid hex characters) that expect `null` results.
- Harden `hexToRgb` to return `null` when the input is not a string by adding a `typeof hex !== 'string'` guard.

### Testing
- Ran quick runtime probes of the conversion functions with `node` to inspect sample round-trip outputs (manual checks, not automated tests), which matched expected behaviors for the sampled cases.
- Attempted to run unit tests with `npm run test:unit`, but `vitest` was not available and the command failed with `sh: 1: vitest: not found`.
- Attempted `npm install` to install dev dependencies but the environment blocked registry access and returned a `403` error, preventing automated test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69938e4d34e48326900d8b4e6644e569)