### PR TITLE
Allow negative padding values in border and canvas settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,19 +80,19 @@
             <details class="option-accordion" aria-label="Canvas image size options">
               <summary class="control-title">Image padding</summary>
               <div class="padding-layout">
-                <input class="pad-input top" type="number" id="image-padding-top" min="0" value="50" aria-label="Image padding top" disabled />
+                <input class="pad-input top" type="number" id="image-padding-top" value="50" aria-label="Image padding top" disabled />
                 <button type="button" class="lock-button top" id="image-lock-top" aria-controls="image-padding-top" aria-pressed="true">🔒</button>
 
-                <input class="pad-input left" type="number" id="image-padding-left" min="0" value="50" aria-label="Image padding left" disabled />
+                <input class="pad-input left" type="number" id="image-padding-left" value="50" aria-label="Image padding left" disabled />
                 <button type="button" class="lock-button left" id="image-lock-left" aria-controls="image-padding-left" aria-pressed="true">🔒</button>
 
-                <input class="pad-input center" type="number" id="image-padding-center" min="0" value="50" aria-label="Image padding center" />
+                <input class="pad-input center" type="number" id="image-padding-center" value="50" aria-label="Image padding center" />
 
                 <button type="button" class="lock-button right" id="image-lock-right" aria-controls="image-padding-right" aria-pressed="true">🔒</button>
-                <input class="pad-input right" type="number" id="image-padding-right" min="0" value="50" aria-label="Image padding right" disabled />
+                <input class="pad-input right" type="number" id="image-padding-right" value="50" aria-label="Image padding right" disabled />
 
                 <button type="button" class="lock-button bottom" id="image-lock-bottom" aria-controls="image-padding-bottom" aria-pressed="true">🔒</button>
-                <input class="pad-input bottom" type="number" id="image-padding-bottom" min="0" value="50" aria-label="Image padding bottom" disabled />
+                <input class="pad-input bottom" type="number" id="image-padding-bottom" value="50" aria-label="Image padding bottom" disabled />
               </div>
             </details>
           </section>
@@ -116,19 +116,19 @@
               <details class="option-accordion">
                 <summary class="control-title">Padding</summary>
                 <div class="padding-layout">
-                  <input class="pad-input top" type="number" id="padding-top" min="0" value="24" aria-label="Padding top" disabled />
+                  <input class="pad-input top" type="number" id="padding-top" value="24" aria-label="Padding top" disabled />
                   <button type="button" class="lock-button top" id="lock-top" aria-controls="padding-top" aria-pressed="true">🔒</button>
 
-                  <input class="pad-input left" type="number" id="padding-left" min="0" value="24" aria-label="Padding left" disabled />
+                  <input class="pad-input left" type="number" id="padding-left" value="24" aria-label="Padding left" disabled />
                   <button type="button" class="lock-button left" id="lock-left" aria-controls="padding-left" aria-pressed="true">🔒</button>
 
-                  <input class="pad-input center" type="number" id="padding-center" min="0" value="24" aria-label="Padding center" />
+                  <input class="pad-input center" type="number" id="padding-center" value="24" aria-label="Padding center" />
 
                   <button type="button" class="lock-button right" id="lock-right" aria-controls="padding-right" aria-pressed="true">🔒</button>
-                  <input class="pad-input right" type="number" id="padding-right" min="0" value="24" aria-label="Padding right" disabled />
+                  <input class="pad-input right" type="number" id="padding-right" value="24" aria-label="Padding right" disabled />
 
                   <button type="button" class="lock-button bottom" id="lock-bottom" aria-controls="padding-bottom" aria-pressed="true">🔒</button>
-                  <input class="pad-input bottom" type="number" id="padding-bottom" min="0" value="24" aria-label="Padding bottom" disabled />
+                  <input class="pad-input bottom" type="number" id="padding-bottom" value="24" aria-label="Padding bottom" disabled />
                 </div>
               </details>
 

--- a/src/app.js
+++ b/src/app.js
@@ -410,6 +410,16 @@ function clampToPositiveNumber(value, fallback = 0) {
   return parsed;
 }
 
+function parsePaddingNumber(value, fallback = 0) {
+  const parsed = Number.parseFloat(value);
+
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
 async function loadImageFromFile(file) {
   if (!file || !file.type || !file.type.startsWith('image/')) {
     throw new Error('Please choose a valid image file.');
@@ -622,7 +632,7 @@ function triggerSaveImage() {
 }
 
 function syncPaddingValues(centerInput, controls, lockStates, fallback) {
-  const centerValue = clampToPositiveNumber(centerInput.value, fallback);
+  const centerValue = parsePaddingNumber(centerInput.value, fallback);
 
   Object.entries(controls).forEach(([side, control]) => {
     const isLocked = lockStates[side];
@@ -682,6 +692,7 @@ function getBorderConfig() {
       sideMode: imageBorderRepeatModeInput?.value || 'stretch',
     },
     clampToPositiveNumber,
+    parsePaddingNumber,
   });
 }
 
@@ -703,6 +714,7 @@ function getCanvasSizePaddingConfig() {
       left: imageSidePaddingControls.left.input.value,
     },
     clampToPositiveNumber,
+    parsePaddingNumber,
   });
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -13,14 +13,16 @@ export function getBorderConfig(inputs) {
     sidePaddingValues,
     imageBorder,
     clampToPositiveNumber,
+    parsePaddingNumber,
   } = inputs;
 
-  const centerPadding = clampToPositiveNumber(centerPaddingValue, 24);
+  const parsePadding = parsePaddingNumber || clampToPositiveNumber;
+  const centerPadding = parsePadding(centerPaddingValue, 24);
   const padding = {
-    top: lockState.top ? centerPadding : clampToPositiveNumber(sidePaddingValues.top, centerPadding),
-    right: lockState.right ? centerPadding : clampToPositiveNumber(sidePaddingValues.right, centerPadding),
-    bottom: lockState.bottom ? centerPadding : clampToPositiveNumber(sidePaddingValues.bottom, centerPadding),
-    left: lockState.left ? centerPadding : clampToPositiveNumber(sidePaddingValues.left, centerPadding),
+    top: lockState.top ? centerPadding : parsePadding(sidePaddingValues.top, centerPadding),
+    right: lockState.right ? centerPadding : parsePadding(sidePaddingValues.right, centerPadding),
+    bottom: lockState.bottom ? centerPadding : parsePadding(sidePaddingValues.bottom, centerPadding),
+    left: lockState.left ? centerPadding : parsePadding(sidePaddingValues.left, centerPadding),
   };
 
   return {
@@ -50,13 +52,15 @@ export function getCanvasSizePaddingConfig(inputs) {
     lockState,
     sidePaddingValues,
     clampToPositiveNumber,
+    parsePaddingNumber,
   } = inputs;
-  const centerPadding = clampToPositiveNumber(centerPaddingValue, 50);
+  const parsePadding = parsePaddingNumber || clampToPositiveNumber;
+  const centerPadding = parsePadding(centerPaddingValue, 50);
 
   return {
-    top: lockState.top ? centerPadding : clampToPositiveNumber(sidePaddingValues.top, centerPadding),
-    right: lockState.right ? centerPadding : clampToPositiveNumber(sidePaddingValues.right, centerPadding),
-    bottom: lockState.bottom ? centerPadding : clampToPositiveNumber(sidePaddingValues.bottom, centerPadding),
-    left: lockState.left ? centerPadding : clampToPositiveNumber(sidePaddingValues.left, centerPadding),
+    top: lockState.top ? centerPadding : parsePadding(sidePaddingValues.top, centerPadding),
+    right: lockState.right ? centerPadding : parsePadding(sidePaddingValues.right, centerPadding),
+    bottom: lockState.bottom ? centerPadding : parsePadding(sidePaddingValues.bottom, centerPadding),
+    left: lockState.left ? centerPadding : parsePadding(sidePaddingValues.left, centerPadding),
   };
 }

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBorderConfig, getCanvasSizePaddingConfig } from '../../src/config.js';
+
+function clampToPositiveNumber(value, fallback = 0) {
+  const parsed = Number.parseFloat(value);
+
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function parsePaddingNumber(value, fallback = 0) {
+  const parsed = Number.parseFloat(value);
+
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+describe('padding config parsing', () => {
+  it('allows negative border padding values', () => {
+    const config = getBorderConfig({
+      enabled: true,
+      borderWidthValue: '2',
+      borderRadiusValue: '16',
+      colorMode: 'solid',
+      color: '#000000',
+      insideOutColorValues: [],
+      backgroundMode: 'transparent',
+      backgroundColor: '#ffffff',
+      centerPaddingValue: '-10',
+      lockState: { top: true, right: false, bottom: false, left: false },
+      sidePaddingValues: { top: '100', right: '-4', bottom: 'abc', left: '3' },
+      imageBorder: {},
+      clampToPositiveNumber,
+      parsePaddingNumber,
+    });
+
+    expect(config.padding).toEqual({
+      top: -10,
+      right: -4,
+      bottom: -10,
+      left: 3,
+    });
+  });
+
+  it('allows negative canvas size padding values', () => {
+    const config = getCanvasSizePaddingConfig({
+      centerPaddingValue: '-20',
+      lockState: { top: false, right: true, bottom: false, left: false },
+      sidePaddingValues: { top: '-1', right: '50', bottom: 'bad', left: '4' },
+      clampToPositiveNumber,
+      parsePaddingNumber,
+    });
+
+    expect(config).toEqual({
+      top: -1,
+      right: -20,
+      bottom: -20,
+      left: 4,
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- The UI and config parsing should allow negative padding values for border and canvas/image padding so users can enter offsets rather than being forced to non-negative numbers.
- Preserve existing positive-only behavior for non-padding numeric controls like border width and radius while making padding parsing more permissive.

### Description
- Removed the HTML `min="0"` restriction from border and image padding `<input>` elements in `index.html` so negative numbers can be entered.
- Added a dedicated `parsePaddingNumber` function in `src/app.js` and switched locked/center padding sync to use it so center-lock propagation preserves negative values.
- Wired `parsePaddingNumber` through to the config layer and updated `src/config.js` so `getBorderConfig` and `getCanvasSizePaddingConfig` use a padding parser (falling back to `clampToPositiveNumber`) for padding fields while still clamping width/radius via `clampToPositiveNumber`.
- Added unit tests in `tests/unit/config.test.js` covering negative padding behavior and invalid-value fallback for both border and canvas padding parsing.

### Testing
- Ran `npm run test:unit` and all unit tests passed; vitest reported 2 test files and 18 tests passing.
- The newly added tests in `tests/unit/config.test.js` passed and verify negative padding is accepted and invalid inputs fall back as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993fdcc0c6c83269a07247c2ff09a6f)