### PR TITLE
Refactor app.js into focused feature modules

### DIFF
--- a/src/border/imageBorder.js
+++ b/src/border/imageBorder.js
@@ -1,0 +1,126 @@
+export function getImageBorderSlotState(imageBorderState, slotType, slotName) {
+  const group = imageBorderState[slotType];
+  return group ? group[slotName] : null;
+}
+
+export function hasReadyImage(slot) {
+  return Boolean(slot && slot.status === 'ready' && slot.image);
+}
+
+export function getSlotImageSize(slot) {
+  if (!hasReadyImage(slot)) {
+    return { width: 0, height: 0 };
+  }
+
+  const width = slot.image.width || slot.image.naturalWidth || 0;
+  const height = slot.image.height || slot.image.naturalHeight || 0;
+  return { width, height };
+}
+
+export function drawSideImage({ context, slot, x, y, width, height, orientation, sideMode }) {
+  if (!hasReadyImage(slot) || width <= 0 || height <= 0) {
+    return false;
+  }
+
+  const sourceImage = slot.image;
+
+  if (sideMode === 'repeat') {
+    const sourceSize = getSlotImageSize(slot);
+    const tileLength = orientation === 'horizontal'
+      ? Math.max(1, sourceSize.width || sourceSize.height || width)
+      : Math.max(1, sourceSize.height || sourceSize.width || height);
+
+    if (orientation === 'horizontal') {
+      let drawX = x;
+      const maxX = x + width;
+      while (drawX < maxX) {
+        const drawWidth = Math.min(tileLength, maxX - drawX);
+        context.drawImage(sourceImage, drawX, y, drawWidth, height);
+        drawX += tileLength;
+      }
+    } else {
+      let drawY = y;
+      const maxY = y + height;
+      while (drawY < maxY) {
+        const drawHeight = Math.min(tileLength, maxY - drawY);
+        context.drawImage(sourceImage, x, drawY, width, drawHeight);
+        drawY += tileLength;
+      }
+    }
+
+    return true;
+  }
+
+  context.drawImage(sourceImage, x, y, width, height);
+  return true;
+}
+
+export function drawImageBorder({ context, borderConfig, borderX, borderY, borderRectWidth, borderRectHeight, drawRoundedRectPath }) {
+  const fallbackColor = borderConfig.color;
+  const { sizingStrategy, sideMode, corners, sides } = borderConfig.imageBorder;
+
+  context.save();
+  drawRoundedRectPath(borderX, borderY, borderRectWidth, borderRectHeight, borderConfig.radius);
+  context.clip();
+
+  const defaultCornerSize = Math.max(1, borderConfig.width);
+  const resolveCornerDrawSize = (slot, slotSize) => {
+    if (!hasReadyImage(slot) || sizingStrategy === 'fixed') {
+      return { width: defaultCornerSize, height: defaultCornerSize };
+    }
+
+    const targetHeight = Math.max(1, borderConfig.width);
+    const safeSourceHeight = Math.max(1, slotSize.height || targetHeight);
+    const scaledWidth = Math.max(1, Math.round((slotSize.width || targetHeight) * (targetHeight / safeSourceHeight)));
+    return { width: scaledWidth, height: targetHeight };
+  };
+
+  const topLeft = corners?.topLeft;
+  const topRight = corners?.topRight;
+  const bottomRight = corners?.bottomRight;
+  const bottomLeft = corners?.bottomLeft;
+
+  const topLeftSize = resolveCornerDrawSize(topLeft, getSlotImageSize(topLeft));
+  const topRightSize = resolveCornerDrawSize(topRight, getSlotImageSize(topRight));
+  const bottomRightSize = resolveCornerDrawSize(bottomRight, getSlotImageSize(bottomRight));
+  const bottomLeftSize = resolveCornerDrawSize(bottomLeft, getSlotImageSize(bottomLeft));
+
+  if (hasReadyImage(topLeft)) context.drawImage(topLeft.image, borderX, borderY, topLeftSize.width, topLeftSize.height);
+  if (hasReadyImage(topRight)) context.drawImage(topRight.image, borderX + borderRectWidth - topRightSize.width, borderY, topRightSize.width, topRightSize.height);
+  if (hasReadyImage(bottomRight)) context.drawImage(bottomRight.image, borderX + borderRectWidth - bottomRightSize.width, borderY + borderRectHeight - bottomRightSize.height, bottomRightSize.width, bottomRightSize.height);
+  if (hasReadyImage(bottomLeft)) context.drawImage(bottomLeft.image, borderX, borderY + borderRectHeight - bottomLeftSize.height, bottomLeftSize.width, bottomLeftSize.height);
+
+  const topSideX = borderX + topLeftSize.width;
+  const topSideWidth = Math.max(0, borderRectWidth - topLeftSize.width - topRightSize.width);
+  const topSideHeight = Math.max(1, Math.max(topLeftSize.height, topRightSize.height, borderConfig.width));
+
+  const bottomSideX = borderX + bottomLeftSize.width;
+  const bottomSideWidth = Math.max(0, borderRectWidth - bottomLeftSize.width - bottomRightSize.width);
+  const bottomSideHeight = Math.max(1, Math.max(bottomLeftSize.height, bottomRightSize.height, borderConfig.width));
+
+  const leftSideY = borderY + topLeftSize.height;
+  const leftSideHeight = Math.max(0, borderRectHeight - topLeftSize.height - bottomLeftSize.height);
+  const leftSideWidth = Math.max(1, Math.max(topLeftSize.width, bottomLeftSize.width, borderConfig.width));
+
+  const rightSideY = borderY + topRightSize.height;
+  const rightSideHeight = Math.max(0, borderRectHeight - topRightSize.height - bottomRightSize.height);
+  const rightSideWidth = Math.max(1, Math.max(topRightSize.width, bottomRightSize.width, borderConfig.width));
+
+  drawSideImage({ context, slot: sides?.top, x: topSideX, y: borderY, width: topSideWidth, height: topSideHeight, orientation: 'horizontal', sideMode });
+  drawSideImage({ context, slot: sides?.bottom, x: bottomSideX, y: borderY + borderRectHeight - bottomSideHeight, width: bottomSideWidth, height: bottomSideHeight, orientation: 'horizontal', sideMode });
+  drawSideImage({ context, slot: sides?.left, x: borderX, y: leftSideY, width: leftSideWidth, height: leftSideHeight, orientation: 'vertical', sideMode });
+  drawSideImage({ context, slot: sides?.right, x: borderX + borderRectWidth - rightSideWidth, y: rightSideY, width: rightSideWidth, height: rightSideHeight, orientation: 'vertical', sideMode });
+
+  context.restore();
+
+  const hasAnyImage = [topLeft, topRight, bottomRight, bottomLeft, sides?.top, sides?.right, sides?.bottom, sides?.left].some(hasReadyImage);
+
+  if (!hasAnyImage) {
+    context.save();
+    context.lineWidth = borderConfig.width;
+    context.strokeStyle = fallbackColor;
+    drawRoundedRectPath(borderX, borderY, borderRectWidth, borderRectHeight, borderConfig.radius);
+    context.stroke();
+    context.restore();
+  }
+}

--- a/src/editor/quillAdapter.js
+++ b/src/editor/quillAdapter.js
@@ -1,0 +1,49 @@
+export function createQuillEditor(Quill, handlers) {
+  return new Quill('#editor', {
+    theme: 'snow',
+    modules: {
+      toolbar: {
+        container: '#editor-toolbar',
+        handlers,
+      },
+    },
+    placeholder: 'Type formatted text here...',
+  });
+}
+
+export function extractDocumentFromDelta(delta) {
+  const lines = [];
+  let currentRuns = [];
+
+  delta.ops.forEach((op) => {
+    if (typeof op.insert !== 'string') {
+      return;
+    }
+
+    const chunks = op.insert.split('\n');
+
+    chunks.forEach((chunk, index) => {
+      if (chunk.length > 0) {
+        currentRuns.push({
+          text: chunk,
+          attributes: op.attributes || {},
+        });
+      }
+
+      if (index < chunks.length - 1) {
+        lines.push({ runs: currentRuns, align: op.attributes?.align || 'left' });
+        currentRuns = [];
+      }
+    });
+  });
+
+  if (currentRuns.length > 0) {
+    lines.push({ runs: currentRuns, align: 'left' });
+  }
+
+  if (lines.length === 0) {
+    lines.push({ runs: [{ text: '', attributes: {} }], align: 'left' });
+  }
+
+  return lines;
+}

--- a/src/render/canvasRenderer.js
+++ b/src/render/canvasRenderer.js
@@ -1,0 +1,100 @@
+import {
+  calculateCanvasDimensions as calculateCanvasDimensionsFromModule,
+  getAlignedStartX,
+  getAlignmentWidth,
+  layoutDocumentForCanvas as layoutDocumentForCanvasFromModule,
+} from '../layout.js';
+
+export function layoutDocumentForCanvas(lines, maxWidth, wrapEnabled, deps) {
+  return layoutDocumentForCanvasFromModule(lines, maxWidth, wrapEnabled, deps);
+}
+
+export function calculateCanvasDimensions(laidOutLines, borderConfig, canvasSizePaddingConfig, maxContentWidth, deps) {
+  return calculateCanvasDimensionsFromModule(
+    laidOutLines,
+    borderConfig,
+    canvasSizePaddingConfig,
+    maxContentWidth,
+    deps,
+  );
+}
+
+export function renderDocumentToCanvas({
+  context,
+  canvas,
+  laidOutLines,
+  borderConfig,
+  canvasBackgroundConfig,
+  canvasSizePaddingConfig,
+  maxContentWidth,
+  measureRenderedVerticalBounds,
+  drawRoundedRectPath,
+  drawImageBorder,
+}) {
+  context.clearRect(0, 0, canvas.width, canvas.height);
+
+  if (canvasBackgroundConfig.mode === 'solid') {
+    context.fillStyle = canvasBackgroundConfig.color;
+    context.fillRect(0, 0, canvas.width, canvas.height);
+  }
+
+  context.textBaseline = 'top';
+
+  const borderWidth = borderConfig.enabled ? borderConfig.width : 0;
+  const textPadding = borderConfig.enabled ? borderConfig.padding : { top: 0, right: 0, bottom: 0, left: 0 };
+
+  const textStartX = canvasSizePaddingConfig.left + borderWidth + textPadding.left;
+  const textStartY = canvasSizePaddingConfig.top + borderWidth + textPadding.top;
+
+  const alignmentWidth = getAlignmentWidth(laidOutLines, maxContentWidth);
+  const lineStartPositions = laidOutLines.map((line) => getAlignedStartX(line.align, textStartX, alignmentWidth, line.width));
+  const renderedMinX = lineStartPositions.length ? Math.min(...lineStartPositions) : textStartX;
+  const renderedMaxX = laidOutLines.reduce((maxX, line, index) => Math.max(maxX, lineStartPositions[index] + line.width), renderedMinX);
+  const verticalBounds = measureRenderedVerticalBounds(laidOutLines, textStartY);
+
+  let borderX = 0;
+  let borderY = 0;
+  let borderRectWidth = 0;
+  let borderRectHeight = 0;
+
+  if (borderConfig.enabled) {
+    borderX = renderedMinX - textPadding.left - borderWidth / 2;
+    borderY = verticalBounds.minY - textPadding.top - borderWidth / 2;
+    borderRectWidth = renderedMaxX - renderedMinX + textPadding.left + textPadding.right + borderWidth;
+    borderRectHeight = verticalBounds.maxY - verticalBounds.minY + textPadding.top + textPadding.bottom + borderWidth;
+
+    if (borderConfig.backgroundMode === 'solid') {
+      const fillInset = borderWidth / 2;
+      context.fillStyle = borderConfig.backgroundColor;
+      drawRoundedRectPath(borderX + fillInset, borderY + fillInset, borderRectWidth - borderWidth, borderRectHeight - borderWidth, Math.max(0, borderConfig.radius - fillInset));
+      context.fill();
+    }
+  }
+
+  if (borderConfig.enabled && borderWidth > 0) {
+    if (borderConfig.colorMode === 'images') {
+      drawImageBorder(borderConfig, borderX, borderY, borderRectWidth, borderRectHeight);
+    } else if (borderConfig.colorMode === 'inside-out') {
+      const palette = borderConfig.insideOutColors.filter((color) => typeof color === 'string' && color.length > 0);
+      const segmentCount = Math.max(1, palette.length);
+      const segmentWidth = borderWidth / segmentCount;
+      const innerInset = borderWidth / 2;
+
+      for (let drawIndex = segmentCount - 1; drawIndex >= 0; drawIndex -= 1) {
+        const strokeWidth = (drawIndex + 1) * segmentWidth;
+        const centerInset = innerInset - (strokeWidth / 2);
+        context.lineWidth = strokeWidth;
+        context.strokeStyle = palette[drawIndex] || borderConfig.color;
+        drawRoundedRectPath(borderX + centerInset, borderY + centerInset, borderRectWidth - (centerInset * 2), borderRectHeight - (centerInset * 2), Math.max(0, borderConfig.radius - centerInset));
+        context.stroke();
+      }
+    } else {
+      context.lineWidth = borderWidth;
+      context.strokeStyle = borderConfig.color;
+      drawRoundedRectPath(borderX, borderY, borderRectWidth, borderRectHeight, borderConfig.radius);
+      context.stroke();
+    }
+  }
+
+  return { textStartX, textStartY, lineStartPositions };
+}

--- a/src/ui/colorPicker.js
+++ b/src/ui/colorPicker.js
@@ -1,0 +1,134 @@
+import { clampNumber, hexToRgb, hsvToRgb, rgbToHex, rgbToHsv } from '../color.js';
+
+export const TRANSPARENT_COLOR_VALUE = 'transparent';
+
+export function setColorPickerFromHex(state, color) {
+  if (!color) {
+    return false;
+  }
+
+  if (color === TRANSPARENT_COLOR_VALUE) {
+    state.alpha = 0;
+    return true;
+  }
+
+  const rgb = hexToRgb(color);
+
+  if (!rgb) {
+    return false;
+  }
+
+  const hsv = rgbToHsv(rgb.red, rgb.green, rgb.blue);
+  state.hue = hsv.hue;
+  state.sat = hsv.sat;
+  state.val = hsv.val;
+  state.alpha = rgb.alpha ?? 255;
+  state.draftHex = rgbToHex(rgb.red, rgb.green, rgb.blue, state.alpha);
+
+  return true;
+}
+
+export function computeColorPickerUiState(state) {
+  const hue = clampNumber(state.hue, 0, 360, 0);
+  const sat = clampNumber(state.sat, 0, 255, 0);
+  const val = clampNumber(state.val, 0, 255, 0);
+  const alpha = clampNumber(state.alpha, 0, 255, 255);
+
+  const rgb = hsvToRgb(hue === 360 ? 0 : hue, sat, val);
+  const hex = rgbToHex(rgb.red, rgb.green, rgb.blue, alpha);
+
+  return {
+    hue,
+    sat,
+    val,
+    alpha,
+    rgb,
+    hex,
+    mapXPercent: (sat / 255) * 100,
+    mapYPercent: 100 - ((val / 255) * 100),
+    sliderYPercent: (hue / 360) * 100,
+  };
+}
+
+export function syncColorPickerUI(state, uiElements) {
+  const nextUiState = computeColorPickerUiState(state);
+  state.hue = nextUiState.hue;
+  state.sat = nextUiState.sat;
+  state.val = nextUiState.val;
+  state.alpha = nextUiState.alpha;
+  state.draftHex = nextUiState.hex;
+
+  const {
+    selectedColorPreview,
+    colorMap,
+    colorMapHandle,
+    colorSliderHandle,
+    colorValueInputs,
+  } = uiElements;
+
+  if (selectedColorPreview) {
+    if (nextUiState.alpha === 0) {
+      selectedColorPreview.style.backgroundColor = '#d1d5db';
+      selectedColorPreview.style.backgroundImage = 'conic-gradient(#e5e7eb 0deg 90deg, #d1d5db 90deg 180deg, #e5e7eb 180deg 270deg, #d1d5db 270deg 360deg)';
+      selectedColorPreview.style.backgroundSize = '8px 8px';
+    } else {
+      selectedColorPreview.style.backgroundColor = `rgb(${nextUiState.rgb.red} ${nextUiState.rgb.green} ${nextUiState.rgb.blue} / ${(nextUiState.alpha / 255).toFixed(3)})`;
+      selectedColorPreview.style.backgroundImage = 'none';
+      selectedColorPreview.style.backgroundSize = 'auto';
+    }
+  }
+
+  if (colorMap) {
+    colorMap.style.background = `linear-gradient(to top, #000000, rgb(0 0 0 / 0%)), linear-gradient(to right, #ffffff, hsl(${nextUiState.hue}, 100%, 50%))`;
+  }
+
+  if (colorMapHandle) {
+    colorMapHandle.style.left = `${nextUiState.mapXPercent}%`;
+    colorMapHandle.style.top = `${nextUiState.mapYPercent}%`;
+  }
+
+  if (colorSliderHandle) {
+    colorSliderHandle.style.top = `${nextUiState.sliderYPercent}%`;
+  }
+
+  if (colorValueInputs?.hue) {
+    colorValueInputs.hue.value = String(nextUiState.hue);
+    colorValueInputs.sat.value = String(nextUiState.sat);
+    colorValueInputs.val.value = String(nextUiState.val);
+    colorValueInputs.red.value = String(nextUiState.rgb.red);
+    colorValueInputs.green.value = String(nextUiState.rgb.green);
+    colorValueInputs.blue.value = String(nextUiState.rgb.blue);
+    colorValueInputs.alpha.value = String(nextUiState.alpha);
+    colorValueInputs.hex.value = nextUiState.hex;
+  }
+}
+
+export function openColorWindowForFormat({
+  colorWindowOverlay,
+  colorWindowTitle,
+  state,
+  targetFormat = 'color',
+  getSelectionColor,
+}) {
+  if (!colorWindowOverlay) {
+    return;
+  }
+
+  state.targetFormat = targetFormat;
+  state.targetInput = null;
+
+  if (colorWindowTitle) {
+    colorWindowTitle.textContent = targetFormat === 'background' ? 'Highlight Color' : 'Text Color';
+  }
+
+  const selectionColor = getSelectionColor(targetFormat);
+  if (typeof selectionColor === 'string' && selectionColor.trim()) {
+    const didUpdatePicker = setColorPickerFromHex(state, selectionColor);
+    if (didUpdatePicker) {
+      state.activeHex = state.draftHex;
+    }
+  }
+
+  colorWindowOverlay.classList.remove('hidden');
+  colorWindowOverlay.setAttribute('aria-hidden', 'false');
+}

--- a/src/ui/settings.js
+++ b/src/ui/settings.js
@@ -1,0 +1,55 @@
+export const DEFAULT_SETTINGS_STORAGE_KEY = 'text-box-generator-settings';
+
+export function openSettingsWindow(settingsOverlay) {
+  if (!settingsOverlay) {
+    return;
+  }
+
+  settingsOverlay.classList.remove('hidden');
+  settingsOverlay.setAttribute('aria-hidden', 'false');
+}
+
+export function closeSettingsWindow(settingsOverlay) {
+  if (!settingsOverlay) {
+    return;
+  }
+
+  settingsOverlay.classList.add('hidden');
+  settingsOverlay.setAttribute('aria-hidden', 'true');
+}
+
+export function getSavedSettings(storage, storageKey = DEFAULT_SETTINGS_STORAGE_KEY) {
+  try {
+    const rawSettings = storage.getItem(storageKey);
+    if (!rawSettings) {
+      return {};
+    }
+
+    const parsedSettings = JSON.parse(rawSettings);
+    if (!parsedSettings || typeof parsedSettings !== 'object') {
+      return {};
+    }
+
+    return parsedSettings;
+  } catch {
+    return {};
+  }
+}
+
+export function persistSettings(storage, settingsPayload, storageKey = DEFAULT_SETTINGS_STORAGE_KEY) {
+  try {
+    storage.setItem(storageKey, JSON.stringify(settingsPayload));
+  } catch {
+    // Ignore storage failures and continue with in-memory state.
+  }
+}
+
+export function applySavedSettings({ storage, darkModeToggle, applyDarkMode, storageKey = DEFAULT_SETTINGS_STORAGE_KEY }) {
+  if (!darkModeToggle) {
+    return;
+  }
+
+  const savedSettings = getSavedSettings(storage, storageKey);
+  darkModeToggle.checked = Boolean(savedSettings.darkMode);
+  applyDarkMode(darkModeToggle.checked);
+}


### PR DESCRIPTION
### Motivation
- Break up a large `src/app.js` into smaller, testable modules to isolate UI, rendering, border, and editor logic and make unit testing easier.
- Expose pure logic paths as module-level exports so Vitest can cover logic without heavy jsdom setup.

### Description
- Split color picker behavior into `src/ui/colorPicker.js` and exported pure helpers such as `setColorPickerFromHex` and `computeColorPickerUiState`, plus DOM-sync helpers `syncColorPickerUI` and `openColorWindowForFormat`.
- Extract settings/dark-mode persistence into `src/ui/settings.js` with `getSavedSettings`, `persistSettings`, and `applySavedSettings` that accept a `storage` dependency.
- Move image-border helpers to `src/border/imageBorder.js` exporting `getImageBorderSlotState`, `drawSideImage`, `drawImageBorder`, `hasReadyImage`, and `getSlotImageSize`.
- Add `src/render/canvasRenderer.js` to expose `layoutDocumentForCanvas`, `calculateCanvasDimensions`, and `renderDocumentToCanvas` with injectable dependencies for measurement/rendering.
- Add `src/editor/quillAdapter.js` to encapsulate Quill construction via `createQuillEditor` and `extractDocumentFromDelta` for delta-to-document conversion.
- Update `src/app.js` to remain a small orchestrator that queries DOM nodes, wires the modules together (imports the new modules), delegates the previously extracted functions to the modules, and registers event listeners; the original app behavior and event flow are preserved.

### Testing
- Ran unit tests with `npm run test:unit` and all unit tests passed: 3 test files, 20 tests (Vitest run succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699684aae9348326afa8a4577bd62060)