### PR TITLE
Add deterministic unit coverage for layout tokenization and alignment logic

### DIFF
--- a/tests/unit/layout.test.js
+++ b/tests/unit/layout.test.js
@@ -1,6 +1,147 @@
 import { describe, expect, it } from 'vitest';
 
-import { calculateCanvasDimensions } from '../../src/layout.js';
+import {
+  calculateCanvasDimensions,
+  getAlignedStartX,
+  getAlignmentWidth,
+  layoutDocumentForCanvas,
+  tokenizeText,
+} from '../../src/layout.js';
+
+describe('tokenizeText', () => {
+  it('splits mixed words, spaces, and newlines into stable tokens', () => {
+    expect(tokenizeText('Hello  world\nnext\tline')).toEqual([
+      'Hello',
+      '  ',
+      'world',
+      '\n',
+      'next',
+      '\t',
+      'line',
+    ]);
+  });
+
+  it('returns a single all-whitespace token for all-whitespace input', () => {
+    expect(tokenizeText('  \n\t  ')).toEqual(['  \n\t  ']);
+  });
+
+  it('falls back to an empty token for empty string input', () => {
+    expect(tokenizeText('')).toEqual(['']);
+  });
+});
+
+describe('layoutDocumentForCanvas', () => {
+  const buildDeps = ({ defaultFontSize = 10, tokenWidths = {} } = {}) => ({
+    defaultFontSize,
+    getCanvasStyle: (attributes = {}) => ({
+      fontSize: attributes.fontSize ?? defaultFontSize,
+      fontWeight: attributes.bold ? 700 : 400,
+      fontStyle: attributes.italic ? 'italic' : 'normal',
+      fontFamily: 'UnitTestSans',
+    }),
+    buildCanvasFont: (style) => `${style.fontStyle} ${style.fontWeight} ${style.fontSize}px ${style.fontFamily}`,
+    measureText: (text) => tokenWidths[text] ?? text.length,
+  });
+
+  it('wraps on token boundaries only when wrapping is enabled', () => {
+    const lines = [
+      {
+        align: 'left',
+        runs: [
+          { text: 'Hello world again', attributes: {} },
+        ],
+      },
+    ];
+    const deps = buildDeps({
+      tokenWidths: {
+        Hello: 5,
+        ' ': 1,
+        world: 5,
+        again: 5,
+      },
+    });
+
+    const wrapped = layoutDocumentForCanvas(lines, 10, true, deps);
+    const unwrapped = layoutDocumentForCanvas(lines, 10, false, deps);
+
+    expect(wrapped).toHaveLength(3);
+    expect(wrapped[0].tokens.map((token) => token.text)).toEqual(['Hello', ' ']);
+    expect(wrapped[1].tokens.map((token) => token.text)).toEqual(['world', ' ']);
+    expect(wrapped[2].tokens.map((token) => token.text)).toEqual(['again']);
+    expect(wrapped[0].width).toBe(6);
+    expect(wrapped[1].width).toBe(6);
+    expect(wrapped[2].width).toBe(5);
+
+    expect(unwrapped).toHaveLength(1);
+    expect(unwrapped[0].tokens.map((token) => token.text)).toEqual(['Hello', ' ', 'world', ' ', 'again']);
+    expect(unwrapped[0].width).toBe(17);
+  });
+
+  it('preserves explicit empty lines when line.runs is empty', () => {
+    const laidOut = layoutDocumentForCanvas(
+      [{ align: 'center', runs: [] }],
+      120,
+      true,
+      buildDeps({ defaultFontSize: 10 }),
+    );
+
+    expect(laidOut).toEqual([
+      {
+        align: 'center',
+        tokens: [],
+        width: 0,
+        lineHeight: 14,
+      },
+    ]);
+  });
+
+  it('sets lineHeight from the maximum font size in a line', () => {
+    const laidOut = layoutDocumentForCanvas(
+      [{
+        align: 'left',
+        runs: [
+          { text: 'small', attributes: { fontSize: 12 } },
+          { text: 'BIG', attributes: { fontSize: 20 } },
+        ],
+      }],
+      999,
+      false,
+      buildDeps({ defaultFontSize: 10 }),
+    );
+
+    expect(laidOut).toHaveLength(1);
+    expect(laidOut[0].lineHeight).toBe(Math.round(20 * 1.35));
+  });
+});
+
+describe('getAlignedStartX', () => {
+  it('returns deterministic start positions for left/center/right', () => {
+    expect(getAlignedStartX('left', 10, 100, 40)).toBe(10);
+    expect(getAlignedStartX('center', 10, 100, 40)).toBe(40);
+    expect(getAlignedStartX('right', 10, 100, 40)).toBe(70);
+  });
+});
+
+describe('getAlignmentWidth', () => {
+  it('selects the widest laid out line when under maxContentWidth', () => {
+    const lines = [
+      { width: 40 },
+      { width: 120 },
+      { width: 75 },
+    ];
+
+    expect(getAlignmentWidth(lines, 200)).toBe(120);
+  });
+
+  it('clamps widest line width to maxContentWidth', () => {
+    const lines = [
+      { width: 80 },
+      { width: 180 },
+    ];
+
+    expect(getAlignmentWidth(lines, 150)).toBe(150);
+  });
+});
 
 describe('calculateCanvasDimensions', () => {
   it('sizes border to rendered centered content width plus padding', () => {


### PR DESCRIPTION
### Motivation
- Ensure deterministic, fast unit coverage for layout helpers responsible for tokenization, wrapping, alignment, and line sizing.
- Use existing dependency injection in `layoutDocumentForCanvas` to avoid flaky measurement and keep tests isolated.

### Description
- Expanded `tests/unit/layout.test.js` with a dedicated `tokenizeText` suite covering mixed whitespace/newlines, all-whitespace, and empty-string fallback cases.
- Added a `layoutDocumentForCanvas` suite that injects test doubles for `getCanvasStyle`, `buildCanvasFont`, `measureText`, and `defaultFontSize` to assert wrapping-on/off behavior, token-boundary wrapping outcomes, explicit empty `line.runs` handling, and line height derived from the maximum font size in a line.
- Added focused suites for `getAlignedStartX` to assert left/center/right deterministic offsets and `getAlignmentWidth` to verify widest-line selection and `maxContentWidth` clamping behavior.

### Testing
- Ran `npm test -- tests/unit/layout.test.js` which initially reported one failing assertion in the wrapping test (observed during development). 
- Ran `npx vitest --environment jsdom tests/unit/layout.test.js` and confirmed the file's tests all passed (`11 tests` passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699750421d7c8326bcb4deaa8c56427d)