### PR TITLE
Clip repeated image-border tiles instead of compressing final tile

### DIFF
--- a/src/border/imageBorder.js
+++ b/src/border/imageBorder.js
@@ -30,23 +30,28 @@ export function drawSideImage({ context, slot, x, y, width, height, orientation,
       ? Math.max(1, sourceSize.width || sourceSize.height || width)
       : Math.max(1, sourceSize.height || sourceSize.width || height);
 
+    context.save();
+    context.beginPath();
+    context.rect(x, y, width, height);
+    context.clip();
+
     if (orientation === 'horizontal') {
       let drawX = x;
       const maxX = x + width;
       while (drawX < maxX) {
-        const drawWidth = Math.min(tileLength, maxX - drawX);
-        context.drawImage(sourceImage, drawX, y, drawWidth, height);
+        context.drawImage(sourceImage, drawX, y, tileLength, height);
         drawX += tileLength;
       }
     } else {
       let drawY = y;
       const maxY = y + height;
       while (drawY < maxY) {
-        const drawHeight = Math.min(tileLength, maxY - drawY);
-        context.drawImage(sourceImage, x, drawY, width, drawHeight);
+        context.drawImage(sourceImage, x, drawY, width, tileLength);
         drawY += tileLength;
       }
     }
+
+    context.restore();
 
     return true;
   }

--- a/tests/unit/imageBorder.test.js
+++ b/tests/unit/imageBorder.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { drawSideImage } from '../../src/border/imageBorder.js';
+
+describe('drawSideImage repeat mode', () => {
+  it('draws full-sized tiles and truncates overflow via clipping instead of compressing final tile', () => {
+    const drawCalls = [];
+    const context = {
+      save: () => {},
+      beginPath: () => {},
+      rect: () => {},
+      clip: () => {},
+      restore: () => {},
+      drawImage: (...args) => drawCalls.push(args),
+    };
+
+    const image = { width: 10, height: 4 };
+    const result = drawSideImage({
+      context,
+      slot: { status: 'ready', image },
+      x: 0,
+      y: 0,
+      width: 25,
+      height: 5,
+      orientation: 'horizontal',
+      sideMode: 'repeat',
+    });
+
+    expect(result).toBe(true);
+    expect(drawCalls).toHaveLength(3);
+
+    // 25px area with 10px tiles should draw at x=0,10,20 all with full 10px width,
+    // with the last one clipped to the border area.
+    expect(drawCalls[0]).toEqual([image, 0, 0, 10, 5]);
+    expect(drawCalls[1]).toEqual([image, 10, 0, 10, 5]);
+    expect(drawCalls[2]).toEqual([image, 20, 0, 10, 5]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent the last tile in image-border repeat mode from being scaled to fit remaining pixels and instead have it truncated by the border bounds for correct visual fidelity.

### Description
- Change `drawSideImage` to always draw full-size tiles and apply a clipping rectangle for the side segment so overflow is truncated rather than resized, updating `src/border/imageBorder.js`.
- Replace per-tile variable sizing with fixed `tileLength` draws for both horizontal and vertical orientations and surround repeated draws with `context.save()`, `context.rect(...)`, `context.clip()` and `context.restore()`.
- Add a unit test `tests/unit/imageBorder.test.js` that asserts three full 10px tiles are drawn for a 25px horizontal segment and relies on clipping for the trailing overflow.

### Testing
- Ran unit tests with `npm run test:unit`, and all unit tests passed (`4` test files, `51` tests, all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997ac680afc832699e56c91743a6db6)