### PR TITLE
Keep wrap/max-width/manage-fonts controls on one line

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -315,10 +315,20 @@ body.dark-mode .border-options {
 
 
 .wrap-text-controls {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 0.9rem;
-  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.wrap-text-controls .inline-checkbox,
+.wrap-text-controls .manage-fonts-button {
+  white-space: nowrap;
+}
+
+.wrap-text-controls .inline-input {
+  min-width: 0;
+  justify-content: flex-start;
 }
 
 .manage-fonts-button {
@@ -347,7 +357,8 @@ body.dark-mode .border-options {
 }
 
 .compact-input input {
-  width: 7rem;
+  width: min(7rem, 100%);
+  min-width: 0;
   padding: 0.35rem 0.5rem;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent the "Wrap text", "Max image width", and "Manage Fonts" controls from wrapping and overflowing at smaller widths by stabilizing their layout and allowing the numeric input to shrink.

### Description
- Replace `.wrap-text-controls` flex with a 3-column grid (`auto minmax(0, 1fr) auto`), add `white-space: nowrap` for the checkbox label and manage-fonts button, allow the inline input group to shrink via `min-width: 0`, and constrain the max-image-width input with `width: min(7rem, 100%); min-width: 0;` in `styles.css`.

### Testing
- Ran `npm run test:unit` and all unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c698ff4c883268456a2217713b5e1)