### PR TITLE
Add border padding rounding controls for repeat image borders

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,28 @@
                   <button type="button" class="lock-button bottom" id="lock-bottom" aria-controls="padding-bottom" aria-pressed="true">🔒</button>
                   <input class="pad-input bottom" type="number" id="padding-bottom" value="24" aria-label="Padding bottom" disabled />
                 </div>
+                <div class="border-padding-rounding">
+                  <h4>Border padding rounding</h4>
+                  <p class="option-description">When using image borders in repeat mode, these options can round rendered border padding so repeated side images fill evenly. This only affects the final rendered image and does not change the padding textbox values.</p>
+                  <div class="border-input-row border-padding-rounding-row">
+                    <label for="border-padding-round-horizontal">Round horizontal padding</label>
+                    <select id="border-padding-round-horizontal" disabled>
+                      <option value="none" selected>None</option>
+                      <option value="nearest">Nearest</option>
+                      <option value="up">Up</option>
+                      <option value="down">Down</option>
+                    </select>
+                  </div>
+                  <div class="border-input-row border-padding-rounding-row">
+                    <label for="border-padding-round-vertical">Round vertical padding</label>
+                    <select id="border-padding-round-vertical" disabled>
+                      <option value="none" selected>None</option>
+                      <option value="nearest">Nearest</option>
+                      <option value="up">Up</option>
+                      <option value="down">Down</option>
+                    </select>
+                  </div>
+                </div>
               </details>
 
               <details class="option-accordion" aria-label="Border color options">

--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
                 </div>
                 <div class="border-padding-rounding">
                   <h4>Border padding rounding</h4>
-                  <p class="option-description">When using image borders in repeat mode, these options can round rendered border padding so repeated side images fill evenly. This only affects the final rendered image and does not change the padding textbox values.</p>
+                  <p class="option-description">When using image borders in repeat mode, these options can round rendered border padding so repeated side images fill evenly.</p>
                   <div class="border-input-row border-padding-rounding-row">
                     <label for="border-padding-round-horizontal">Round horizontal padding</label>
                     <select id="border-padding-round-horizontal" disabled>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textbox-generator",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "private": true,
   "scripts": {
     "dev": "node --watch server/index.js",

--- a/src/app.js
+++ b/src/app.js
@@ -78,7 +78,7 @@ const settingsButton = settingsView.window.openButton;
 const settingsOverlay = settingsView.window.overlay;
 const closeSettingsWindowButton = settingsView.window.closeButton;
 const darkModeToggle = settingsView.preferences.darkModeToggle;
-const APP_VERSION = '1.1.9';
+const APP_VERSION = '1.1.10';
 const BASE_CANVAS_CONTENT_WIDTH = 900;
 const SETTINGS_STORAGE_KEY = DEFAULT_SETTINGS_STORAGE_KEY;
 
@@ -105,6 +105,8 @@ const insideOutAddColorButton = borderControlsView.insideOut.addColorButton;
 const imageBorderControls = borderControlsView.imageBorder.controls;
 const imageBorderSizingModeInput = borderControlsView.imageBorder.sizingModeInput;
 const imageBorderRepeatModeInput = borderControlsView.imageBorder.repeatModeInput;
+const borderPaddingRoundHorizontalInput = borderControlsView.imageBorder.paddingRoundHorizontalInput;
+const borderPaddingRoundVerticalInput = borderControlsView.imageBorder.paddingRoundVerticalInput;
 const imageBorderCornerButtons = borderControlsView.imageBorder.cornerButtons;
 const imageBorderSideButtons = borderControlsView.imageBorder.sideButtons;
 const imageBorderTransformInputs = borderControlsView.imageBorder.transformInputs;
@@ -982,11 +984,13 @@ const manageImagesWindowController = createManageImagesWindowController({
   onSelectionApplied: ({ slotType, slotName }, imageId) => {
     assignManagedImageToSlot(slotType, slotName, imageId);
     borderState.updatePieceButtonLabel(slotType, slotName);
+    borderController.updatePaddingRoundingInputsState();
     borderTemplateFeature.markDirty();
     drawEditorToCanvas();
   },
   onStoreChanged: () => {
     borderState.updateAllPieceButtonLabels();
+    borderController.updatePaddingRoundingInputsState();
     persistImageLibrary();
   },
   onImagesDeleted: borderState.clearDeletedImageSlots,
@@ -1172,6 +1176,8 @@ const borderController = createBorderUiController({
     borderColorInput,
     imageBorderSizingModeInput,
     imageBorderRepeatModeInput,
+    borderPaddingRoundHorizontalInput,
+    borderPaddingRoundVerticalInput,
     backgroundColorInput,
     borderBackgroundColorTransparentRadio,
     borderBackgroundColorSolidRadio,
@@ -1220,6 +1226,7 @@ const borderController = createBorderUiController({
       const slotState = getImageBorderSlotState(slotType, slotName);
       clearImageBorderSlot(slotState);
       borderState.updatePieceButtonLabel(slotType, slotName);
+      borderController.updatePaddingRoundingInputsState();
     },
     updateCanvasBackgroundControlsState,
     syncColorPreviewButtons,
@@ -1254,6 +1261,8 @@ const borderTemplateAdapterService = createBorderTemplateAdapterService({
     sidePaddingControls,
     imageBorderSizingModeInput,
     imageBorderRepeatModeInput,
+    borderPaddingRoundHorizontalInput,
+    borderPaddingRoundVerticalInput,
     imageBorderTransformInputs,
   },
   state: {

--- a/src/border/templateLibraryStore.js
+++ b/src/border/templateLibraryStore.js
@@ -24,6 +24,10 @@ const DEFAULT_BORDER_TEMPLATE_DATA = {
     bottom: '24',
     left: '24',
   },
+  paddingRounding: {
+    horizontal: 'none',
+    vertical: 'none',
+  },
   imageBorder: {
     corners: {
       topLeft: { imageId: null, rotation: 0, flipX: false, flipY: false },

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,7 @@ export function getBorderConfig(inputs) {
     lockState,
     sidePaddingValues,
     imageBorder,
+    paddingRounding,
     clampToPositiveNumber,
     parsePaddingNumber,
   } = inputs;
@@ -33,6 +34,7 @@ export function getBorderConfig(inputs) {
     color,
     insideOutColors: insideOutColorValues,
     imageBorder,
+    paddingRounding,
     backgroundMode,
     backgroundColor,
     padding,

--- a/src/controllers/borderController.js
+++ b/src/controllers/borderController.js
@@ -30,6 +30,8 @@ export function createBorderController({ elements, actions, callbacks }) {
       borderColorInput,
       imageBorderSizingModeInput,
       imageBorderRepeatModeInput,
+      borderPaddingRoundHorizontalInput,
+      borderPaddingRoundVerticalInput,
       backgroundColorInput,
       borderBackgroundColorTransparentRadio,
       borderBackgroundColorSolidRadio,
@@ -176,7 +178,12 @@ export function createBorderController({ elements, actions, callbacks }) {
       onRenderRequested?.();
     });
 
-    [imageBorderSizingModeInput, imageBorderRepeatModeInput].forEach((input) => {
+    [
+      imageBorderSizingModeInput,
+      imageBorderRepeatModeInput,
+      borderPaddingRoundHorizontalInput,
+      borderPaddingRoundVerticalInput,
+    ].forEach((input) => {
       events.on(input, 'change', () => {
         onStateChanged?.();
         onRenderRequested?.();

--- a/src/features/border/borderConfigAdapter.js
+++ b/src/features/border/borderConfigAdapter.js
@@ -13,6 +13,8 @@ export function createBorderConfigAdapter({ elements, state, helpers }) {
       sidePaddingControls,
       imageBorderSizingModeInput,
       imageBorderRepeatModeInput,
+      borderPaddingRoundHorizontalInput,
+      borderPaddingRoundVerticalInput,
     } = elements;
 
     const {
@@ -51,6 +53,10 @@ export function createBorderConfigAdapter({ elements, state, helpers }) {
         sides: resolveRenderableImageBorderGroup(imageBorderState.sides, getManagedImageById),
         sizingStrategy: imageBorderSizingModeInput?.value || 'auto',
         sideMode: imageBorderRepeatModeInput?.value || 'stretch',
+      },
+      paddingRounding: {
+        horizontal: borderPaddingRoundHorizontalInput?.value || 'none',
+        vertical: borderPaddingRoundVerticalInput?.value || 'none',
       },
       clampToPositiveNumber,
       parsePaddingNumber,

--- a/src/features/border/borderTemplateAdapterService.js
+++ b/src/features/border/borderTemplateAdapterService.js
@@ -36,6 +36,8 @@ export function createBorderTemplateAdapterService({
       sidePaddingControls,
       imageBorderSizingModeInput,
       imageBorderRepeatModeInput,
+      borderPaddingRoundHorizontalInput,
+      borderPaddingRoundVerticalInput,
     } = elements;
 
     return {
@@ -60,6 +62,10 @@ export function createBorderTemplateAdapterService({
         right: sidePaddingControls.right.input.value,
         bottom: sidePaddingControls.bottom.input.value,
         left: sidePaddingControls.left.input.value,
+      },
+      paddingRounding: {
+        horizontal: borderPaddingRoundHorizontalInput?.value || 'none',
+        vertical: borderPaddingRoundVerticalInput?.value || 'none',
       },
       imageBorder: {
         corners: cloneImageBorderGroup(state.imageBorderState.corners),
@@ -96,6 +102,8 @@ export function createBorderTemplateAdapterService({
       sidePaddingControls,
       imageBorderSizingModeInput,
       imageBorderRepeatModeInput,
+      borderPaddingRoundHorizontalInput,
+      borderPaddingRoundVerticalInput,
       imageBorderTransformInputs,
     } = elements;
 
@@ -160,6 +168,14 @@ export function createBorderTemplateAdapterService({
 
     if (imageBorderRepeatModeInput) {
       imageBorderRepeatModeInput.value = normalizedTemplateData?.imageBorder?.sideMode || imageBorderRepeatModeInput.value;
+    }
+
+    if (borderPaddingRoundHorizontalInput) {
+      borderPaddingRoundHorizontalInput.value = normalizedTemplateData?.paddingRounding?.horizontal || 'none';
+    }
+
+    if (borderPaddingRoundVerticalInput) {
+      borderPaddingRoundVerticalInput.value = normalizedTemplateData?.paddingRounding?.vertical || 'none';
     }
 
     updateBorderControlsState();

--- a/src/layout.js
+++ b/src/layout.js
@@ -107,6 +107,35 @@ function roundLengthToMode(length, tileLength, mode) {
   return length;
 }
 
+function hasImageDimensions(slot) {
+  return Boolean(slot?.image && ((slot.image.width || slot.image.naturalWidth || 0) > 0) && ((slot.image.height || slot.image.naturalHeight || 0) > 0));
+}
+
+function getImageDimensions(slot) {
+  if (!hasImageDimensions(slot)) {
+    return { width: 0, height: 0 };
+  }
+
+  return {
+    width: slot.image.width || slot.image.naturalWidth || 0,
+    height: slot.image.height || slot.image.naturalHeight || 0,
+  };
+}
+
+function resolveCornerDrawSize(borderConfig, slot) {
+  const defaultCornerSize = Math.max(1, borderConfig.width);
+  const sourceSize = getImageDimensions(slot);
+
+  if (!hasImageDimensions(slot) || borderConfig.imageBorder?.sizingStrategy === 'fixed') {
+    return { width: defaultCornerSize, height: defaultCornerSize };
+  }
+
+  const targetHeight = Math.max(1, borderConfig.width);
+  const safeSourceHeight = Math.max(1, sourceSize.height || targetHeight);
+  const scaledWidth = Math.max(1, Math.round((sourceSize.width || targetHeight) * (targetHeight / safeSourceHeight)));
+  return { width: scaledWidth, height: targetHeight };
+}
+
 function resolveRoundedPadding(borderConfig, contentWidth, contentHeight) {
   const basePadding = borderConfig.padding;
   const imageBorder = borderConfig.imageBorder || {};
@@ -125,15 +154,23 @@ function resolveRoundedPadding(borderConfig, contentWidth, contentHeight) {
   const leftHeight = imageBorder?.sides?.left?.image?.height || imageBorder?.sides?.left?.image?.naturalHeight || 0;
   const rightHeight = imageBorder?.sides?.right?.image?.height || imageBorder?.sides?.right?.image?.naturalHeight || 0;
 
+  const topLeftSize = resolveCornerDrawSize(borderConfig, imageBorder?.corners?.topLeft);
+  const topRightSize = resolveCornerDrawSize(borderConfig, imageBorder?.corners?.topRight);
+  const bottomLeftSize = resolveCornerDrawSize(borderConfig, imageBorder?.corners?.bottomLeft);
+
   if (horizontalMode !== 'none' && topWidth > 0 && topWidth === bottomWidth) {
     const borderRectWidth = contentWidth + basePadding.left + basePadding.right + borderConfig.width;
-    const roundedWidth = roundLengthToMode(borderRectWidth, topWidth, horizontalMode);
+    const sideLength = Math.max(0, borderRectWidth - topLeftSize.width - topRightSize.width);
+    const roundedSideLength = roundLengthToMode(sideLength, topWidth, horizontalMode);
+    const roundedWidth = roundedSideLength + topLeftSize.width + topRightSize.width;
     roundedPadding.right = Math.max(0, basePadding.right + (roundedWidth - borderRectWidth));
   }
 
   if (verticalMode !== 'none' && leftHeight > 0 && leftHeight === rightHeight) {
     const borderRectHeight = contentHeight + basePadding.top + basePadding.bottom + borderConfig.width;
-    const roundedHeight = roundLengthToMode(borderRectHeight, leftHeight, verticalMode);
+    const sideLength = Math.max(0, borderRectHeight - topLeftSize.height - bottomLeftSize.height);
+    const roundedSideLength = roundLengthToMode(sideLength, leftHeight, verticalMode);
+    const roundedHeight = roundedSideLength + topLeftSize.height + bottomLeftSize.height;
     roundedPadding.bottom = Math.max(0, basePadding.bottom + (roundedHeight - borderRectHeight));
   }
 

--- a/src/ui/views/borderControlsView.js
+++ b/src/ui/views/borderControlsView.js
@@ -43,6 +43,8 @@ export function createBorderControlsView(documentRef) {
       controls: getRequiredElementById(documentRef, 'image-border-controls'),
       sizingModeInput: getRequiredElementById(documentRef, 'image-border-sizing-mode'),
       repeatModeInput: getRequiredElementById(documentRef, 'image-border-repeat-mode'),
+      paddingRoundHorizontalInput: getRequiredElementById(documentRef, 'border-padding-round-horizontal'),
+      paddingRoundVerticalInput: getRequiredElementById(documentRef, 'border-padding-round-vertical'),
       cornerButtons: {
         topLeft: getRequiredElementById(documentRef, 'image-border-corner-top-left'),
         topRight: getRequiredElementById(documentRef, 'image-border-corner-top-right'),

--- a/styles.css
+++ b/styles.css
@@ -574,6 +574,25 @@ body.dark-mode .lock-button {
   grid-area: lockBottom;
 }
 
+
+.border-padding-rounding {
+  margin-top: 0.6rem;
+}
+
+.border-padding-rounding h4 {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.border-padding-rounding .option-description {
+  margin-top: 0.25rem;
+}
+
+.border-padding-rounding-row {
+  margin-top: 0.35rem;
+}
+
 .border-input-row {
   display: flex;
   align-items: center;

--- a/tests/unit/layout.test.js
+++ b/tests/unit/layout.test.js
@@ -212,8 +212,8 @@ describe('calculateCanvasDimensions', () => {
       },
     );
 
-    expect(dimensions.width).toBe(178);
-    expect(dimensions.height).toBe(72);
+    expect(dimensions.width).toBe(186);
+    expect(dimensions.height).toBe(68);
   });
 
   it('still expands to rendered text width when border is disabled', () => {

--- a/tests/unit/layout.test.js
+++ b/tests/unit/layout.test.js
@@ -185,6 +185,37 @@ describe('calculateCanvasDimensions', () => {
     expect(dimensions.width).toBe(448);
   });
 
+
+  it('rounds right and bottom rendered border padding for repeat image borders', () => {
+    const dimensions = calculateCanvasDimensions(
+      [{ align: 'left', tokens: [], width: 103, lineHeight: 20 }],
+      {
+        enabled: true,
+        width: 4,
+        colorMode: 'images',
+        padding: { top: 10, right: 20, bottom: 10, left: 20 },
+        paddingRounding: { horizontal: 'nearest', vertical: 'down' },
+        imageBorder: {
+          sideMode: 'repeat',
+          sides: {
+            top: { image: { width: 16, height: 6 } },
+            bottom: { image: { width: 16, height: 6 } },
+            left: { image: { width: 6, height: 12 } },
+            right: { image: { width: 6, height: 12 } },
+          },
+        },
+      },
+      { top: 10, right: 20, bottom: 10, left: 10 },
+      103,
+      {
+        measureRenderedVerticalBounds: () => ({ minY: 24, maxY: 51 }),
+      },
+    );
+
+    expect(dimensions.width).toBe(178);
+    expect(dimensions.height).toBe(72);
+  });
+
   it('still expands to rendered text width when border is disabled', () => {
     const dimensions = calculateCanvasDimensions(
       [{ align: 'center', tokens: [], width: 260, lineHeight: 20 }],

--- a/tests/unit/templateLibraryStore.test.js
+++ b/tests/unit/templateLibraryStore.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { createTemplateLibraryStore, DEFAULT_BORDER_TEMPLATE_ID } from '../../src/border/templateLibraryStore.js';
+
+describe('createTemplateLibraryStore', () => {
+  it('includes border padding rounding defaults in the default template data', () => {
+    const store = createTemplateLibraryStore();
+    const defaultTemplate = store.getTemplate(DEFAULT_BORDER_TEMPLATE_ID);
+
+    expect(defaultTemplate?.data?.paddingRounding).toEqual({
+      horizontal: 'none',
+      vertical: 'none',
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide controls to optionally round rendered border padding when using image borders in `repeat` mode so repeated side images tile evenly without changing the padding input values.
- Keep rounding behavior purely presentational (affects only the final rendered image) and enable it only when it is safe (images match on the relevant axis).
- Preserve template/save/load behavior and make rounding configurable per-template.

### Description
- UI: add a new `Border padding rounding` block under `Border padding` in `index.html` with two dropdowns (`Round horizontal padding` and `Round vertical padding`) offering `None`, `Nearest`, `Up`, `Down`, default disabled; add corresponding styles to `styles.css`.
- Wiring: expose the new inputs via `src/ui/views/borderControlsView.js` and wire them into the app bootstrap (`src/app.js`) and the border template adapter (`src/features/border/borderTemplateAdapterService.js`) so rounding settings are captured and applied with templates.
- Controls & behavior: implement enablement logic and UI syncing in `src/features/border/borderUiController.js` and event listeners in `src/controllers/borderController.js` so dropdowns enable only when border color mode is `images`, side mode is `repeat`, and matching side-image dimensions exist (top/bottom widths for horizontal, left/right heights for vertical), and they reset to `none` when disabled.
- Rendering/layout: add `paddingRounding` to `getBorderConfig` (`src/config.js`) and implement rounding logic in layout/renderer via `resolveRoundedPadding` and `roundLengthToMode` so final rendered right/bottom padding is adjusted according to the selected mode without mutating the padding textboxes (`src/layout.js` and `src/render/canvasRenderer.js`).
- Misc: added unit test coverage for the new behavior (`tests/unit/layout.test.js`) and bumped app version to `1.1.10` (`package.json` and `src/app.js`).

### Testing
- Ran unit tests with `npm run test:unit` and all unit tests passed (`81 passed`).
- Attempted end-to-end tests with `npm run test:e2e` but those failed in this environment due to the Playwright browser executable not being installed (message: run `npx playwright install` to download browsers).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e2668a9d8832686bd84a3f7cbe8a0)