### PR TITLE
Add Credits section to settings dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -433,6 +433,8 @@
             <input type="checkbox" id="dark-mode-toggle" />
             Dark mode
           </label>
+          <h3>Credits</h3>
+          <a href="https://www.flaticon.com/free-icons/eye-dropper" title="eye dropper icon">Eye dropper icon created by nawicon - Flaticon</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Surface attribution information inside the settings dialog so credits are visible to users under the Dark mode option.

### Description
- Added a `Credits` heading and the eye-dropper credit link (copied from `credits.html`) into the settings window body in `index.html` just below the dark mode checkbox.

### Testing
- Ran unit tests with `npm run test:unit`, which completed successfully (`15` test files, `80` tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a094d4c3d48326a595924b1249d4a6)