### PR TITLE
Fix underline rendering across spaces

### DIFF
--- a/src/render/canvasPainter.js
+++ b/src/render/canvasPainter.js
@@ -35,7 +35,7 @@ export function createCanvasPainter({ context, canvas, getBackgroundRectHeightFo
         renderedMinY = Math.min(renderedMinY, glyphTop);
         renderedMaxY = Math.max(renderedMaxY, glyphBottom);
 
-        if (token.style.underline && token.text.trim()) {
+        if (token.style.underline && token.text.length > 0) {
           const underlineY = y + token.style.fontSize + 2;
           const underlineWidth = Math.max(1, token.style.fontSize / 14);
           renderedMaxY = Math.max(renderedMaxY, underlineY + underlineWidth / 2);
@@ -210,7 +210,7 @@ export function createCanvasPainter({ context, canvas, getBackgroundRectHeightFo
         context.fillStyle = token.style.color;
         context.fillText(token.text, x, y);
 
-        if (token.style.underline && token.text.trim()) {
+        if (token.style.underline && token.text.length > 0) {
           const underlineY = y + token.style.fontSize + 2;
           const underlineWidth = Math.max(1, token.style.fontSize / 14);
           context.strokeStyle = token.style.color;

--- a/tests/unit/canvasPainter.test.js
+++ b/tests/unit/canvasPainter.test.js
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { createCanvasPainter } from '../../src/render/canvasPainter.js';
+
+function createMockContext() {
+  const lineSegments = [];
+  let currentMoveTo = null;
+
+  return {
+    lineSegments,
+    clearRect: () => {},
+    fillRect: () => {},
+    fillText: () => {},
+    stroke: () => {},
+    beginPath: () => {
+      currentMoveTo = null;
+    },
+    moveTo: (x, y) => {
+      currentMoveTo = { x, y };
+    },
+    lineTo: (x, y) => {
+      lineSegments.push({ from: currentMoveTo, to: { x, y } });
+    },
+    measureText: () => ({
+      actualBoundingBoxAscent: 8,
+      actualBoundingBoxDescent: 2,
+    }),
+    set font(value) {
+      this._font = value;
+    },
+    get font() {
+      return this._font;
+    },
+    set fillStyle(value) {
+      this._fillStyle = value;
+    },
+    get fillStyle() {
+      return this._fillStyle;
+    },
+    set strokeStyle(value) {
+      this._strokeStyle = value;
+    },
+    get strokeStyle() {
+      return this._strokeStyle;
+    },
+    set lineWidth(value) {
+      this._lineWidth = value;
+    },
+    get lineWidth() {
+      return this._lineWidth;
+    },
+    textBaseline: 'top',
+  };
+}
+
+describe('createCanvasPainter', () => {
+  it('draws underline segments for whitespace tokens when underline is enabled', () => {
+    const context = createMockContext();
+    const painter = createCanvasPainter({
+      context,
+      canvas: { width: 400, height: 200 },
+      getBackgroundRectHeightForFont: () => 12,
+      drawImageBorder: () => {},
+    });
+
+    const tokenStyle = {
+      underline: true,
+      fontSize: 16,
+      color: '#000',
+      background: null,
+    };
+
+    painter.renderDocumentToCanvas(
+      [{
+        align: 'left',
+        width: 15,
+        lineHeight: 20,
+        tokens: [
+          { text: 'A', width: 8, style: tokenStyle, font: 'normal 400 16px sans-serif' },
+          { text: ' ', width: 4, style: tokenStyle, font: 'normal 400 16px sans-serif' },
+          { text: '', width: 0, style: tokenStyle, font: 'normal 400 16px sans-serif' },
+          { text: 'B', width: 3, style: tokenStyle, font: 'normal 400 16px sans-serif' },
+        ],
+      }],
+      { enabled: false, width: 0, padding: { top: 0, right: 0, bottom: 0, left: 0 } },
+      { mode: 'transparent', color: '#fff' },
+      { top: 0, right: 0, bottom: 0, left: 0 },
+      100,
+    );
+
+    expect(context.lineSegments).toHaveLength(3);
+    expect(context.lineSegments[1].to.x - context.lineSegments[1].from.x).toBe(4);
+  });
+});


### PR DESCRIPTION
### Motivation
- Underlines were not being drawn across whitespace tokens because the renderer only considered tokens with non-whitespace characters; empty-string tokens should still be excluded while pure-space tokens must be underlined.

### Description
- Change underline eligibility checks in `src/render/canvasPainter.js` to use `token.text.length > 0` instead of `token.text.trim()` so whitespace tokens are treated as non-empty for underlining in both bounds measurement and stroke drawing.
- Add a unit test `tests/unit/canvasPainter.test.js` that exercises mixed tokens (`'A'`, `' '`, `''`, `'B'`) to confirm spaces produce underline segments while empty-string tokens do not.

### Testing
- Ran the unit test suite with `npm run test:unit`, and all tests passed (16 test files, 81 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a1b06d3883268e02fa516e77852c)