### PR TITLE
Avoid forwarding horizontal wheel events from preview panel

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -473,8 +473,16 @@ function panelHasVerticalScrollbar(panelElement) {
   return panelElement.scrollHeight > panelElement.clientHeight;
 }
 
+function isHorizontalScrollEvent(event) {
+  if (!event) {
+    return false;
+  }
+
+  return event.shiftKey || Math.abs(event.deltaX) > Math.abs(event.deltaY);
+}
+
 function forwardCanvasPanelScrollToFormPanel(event) {
-  if (!formPanel || panelHasVerticalScrollbar(canvasPanel)) {
+  if (!formPanel || panelHasVerticalScrollbar(canvasPanel) || isHorizontalScrollEvent(event) || event.deltaY === 0) {
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Horizontal wheel gestures (e.g. Shift+wheel or dominant `deltaX`) were being forwarded from the preview panel to the form controls when the preview lacked a vertical scrollbar, preventing expected horizontal scrolling in the preview. 

### Description
- Added helper `isHorizontalScrollEvent(event)` in `src/app.js` to detect Shift+wheel and cases where `deltaX` dominates `deltaY`. 
- Updated `forwardCanvasPanelScrollToFormPanel` to skip forwarding when the event is horizontal or when `deltaY === 0`, while preserving the existing check that the preview has no vertical scrollbar. 
- Changes are localized to `src/app.js` and don't affect other scrolling behavior.

### Testing
- Ran `npm run test:unit` and all unit tests passed (`16` test files, `81` tests). 
- Executed an automated Playwright script to load the app and capture a screenshot confirming the app loads correctly with the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ac8509fc83268fc3716fdb65c605)