### PR TITLE
Persist editor template state in IndexedDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textbox-generator",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "private": true,
   "scripts": {
     "dev": "node --watch server/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textbox-generator",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "private": true,
   "scripts": {
     "dev": "node --watch server/index.js",

--- a/src/app.js
+++ b/src/app.js
@@ -10,8 +10,8 @@ import {
 } from './ui/colorPicker.js';
 import {
   DEFAULT_SETTINGS_STORAGE_KEY,
-  applySavedSettings as applySavedSettingsModule,
   closeSettingsWindow as closeSettingsWindowModule,
+  getSavedSettings as getSavedSettingsModule,
   openSettingsWindow as openSettingsWindowModule,
   persistSettings as persistSettingsModule,
 } from './ui/settings.js';
@@ -82,7 +82,7 @@ const settingsButton = settingsView.window.openButton;
 const settingsOverlay = settingsView.window.overlay;
 const closeSettingsWindowButton = settingsView.window.closeButton;
 const darkModeToggle = settingsView.preferences.darkModeToggle;
-const APP_VERSION = '1.1.9';
+const APP_VERSION = '1.1.10';
 const BASE_CANVAS_CONTENT_WIDTH = 900;
 const SETTINGS_STORAGE_KEY = DEFAULT_SETTINGS_STORAGE_KEY;
 
@@ -418,20 +418,36 @@ function applyDarkMode(enabled) {
 }
 
 function persistSettings() {
-  if (!darkModeToggle) {
-    return;
-  }
+  const settingsPayload = {
+    darkMode: Boolean(darkModeToggle?.checked),
+    wrapText: Boolean(wrapTextInput?.checked),
+    maxImageWidth: maxImageWidthInput?.value || '',
+    addBorderAroundText: Boolean(borderToggle?.checked),
+  };
 
-  persistSettingsModule(window.localStorage, { darkMode: Boolean(darkModeToggle.checked) }, SETTINGS_STORAGE_KEY);
+  persistSettingsModule(window.localStorage, settingsPayload, SETTINGS_STORAGE_KEY);
 }
 
 function applySavedSettings() {
-  applySavedSettingsModule({
-    storage: window.localStorage,
-    darkModeToggle,
-    applyDarkMode,
-    storageKey: SETTINGS_STORAGE_KEY,
-  });
+  const savedSettings = getSavedSettingsModule(window.localStorage, SETTINGS_STORAGE_KEY);
+
+  if (darkModeToggle) {
+    darkModeToggle.checked = Boolean(savedSettings.darkMode);
+    applyDarkMode(darkModeToggle.checked);
+  }
+
+  if (wrapTextInput && typeof savedSettings.wrapText === 'boolean') {
+    wrapTextInput.checked = savedSettings.wrapText;
+  }
+
+  if (maxImageWidthInput && typeof savedSettings.maxImageWidth !== 'undefined') {
+    maxImageWidthInput.value = String(savedSettings.maxImageWidth || '');
+  }
+
+  if (borderToggle && typeof savedSettings.addBorderAroundText === 'boolean') {
+    borderToggle.checked = savedSettings.addBorderAroundText;
+    borderToggle.dispatchEvent(new Event('change', { bubbles: true }));
+  }
 }
 
 function setStorageStatusMessage(message = '', isError = false) {

--- a/src/app.js
+++ b/src/app.js
@@ -82,7 +82,7 @@ const settingsButton = settingsView.window.openButton;
 const settingsOverlay = settingsView.window.overlay;
 const closeSettingsWindowButton = settingsView.window.closeButton;
 const darkModeToggle = settingsView.preferences.darkModeToggle;
-const APP_VERSION = '1.1.10';
+const APP_VERSION = '1.1.11';
 const BASE_CANVAS_CONTENT_WIDTH = 900;
 const SETTINGS_STORAGE_KEY = DEFAULT_SETTINGS_STORAGE_KEY;
 
@@ -420,8 +420,6 @@ function applyDarkMode(enabled) {
 function persistSettings() {
   const settingsPayload = {
     darkMode: Boolean(darkModeToggle?.checked),
-    wrapText: Boolean(wrapTextInput?.checked),
-    maxImageWidth: maxImageWidthInput?.value || '',
     addBorderAroundText: Boolean(borderToggle?.checked),
   };
 
@@ -436,13 +434,6 @@ function applySavedSettings() {
     applyDarkMode(darkModeToggle.checked);
   }
 
-  if (wrapTextInput && typeof savedSettings.wrapText === 'boolean') {
-    wrapTextInput.checked = savedSettings.wrapText;
-  }
-
-  if (maxImageWidthInput && typeof savedSettings.maxImageWidth !== 'undefined') {
-    maxImageWidthInput.value = String(savedSettings.maxImageWidth || '');
-  }
 
   if (borderToggle && typeof savedSettings.addBorderAroundText === 'boolean') {
     borderToggle.checked = savedSettings.addBorderAroundText;
@@ -676,6 +667,8 @@ function getEditorTemplateSnapshot() {
     color: format.color || null,
     background: format.background || null,
     align: format.align || 'left',
+    wrapText: Boolean(wrapTextInput?.checked),
+    maxImageWidth: maxImageWidthInput?.value || '',
   };
 }
 
@@ -709,6 +702,15 @@ function applyEditorTemplateSnapshot(templateData) {
   }
 
   quill.formatLine(0, lineLength, 'align', templateData.align && templateData.align !== 'left' ? templateData.align : false, 'silent');
+
+  if (wrapTextInput && typeof templateData.wrapText === 'boolean') {
+    wrapTextInput.checked = templateData.wrapText;
+    syncEditorWrapMode();
+  }
+
+  if (maxImageWidthInput && typeof templateData.maxImageWidth !== 'undefined') {
+    maxImageWidthInput.value = String(templateData.maxImageWidth || '');
+  }
 
   quill.setSelection(index, length, 'silent');
   quill.format('font', templateData.font || false, 'silent');
@@ -938,6 +940,15 @@ quill.on('editor-change', () => {
     return;
   }
 
+  void persistEditorTemplateState();
+});
+
+
+wrapTextInput?.addEventListener('change', () => {
+  void persistEditorTemplateState();
+});
+
+maxImageWidthInput?.addEventListener('input', () => {
   void persistEditorTemplateState();
 });
 

--- a/src/app.js
+++ b/src/app.js
@@ -54,6 +54,10 @@ import {
   persistFontLibraryToIndexedDb,
   restoreFontLibraryFromIndexedDb,
 } from './fonts/fontPersistenceIndexedDb.js';
+import {
+  persistEditorTemplateToIndexedDb,
+  restoreEditorTemplateFromIndexedDb,
+} from './editor/editorTemplatePersistenceIndexedDb.js';
 import { createManageFontsWindowController } from './ui/manageFontsWindow.js';
 
 const Quill = window.Quill;
@@ -642,6 +646,67 @@ quill.setContents([
 let activeFontSize = 18;
 let lastKnownSelection = null;
 let isEditingFontSizeInput = false;
+let isApplyingEditorTemplate = false;
+
+function getEditorTemplateSnapshot() {
+  const selection = quill.getSelection() || lastKnownSelection || { index: 0, length: 0 };
+  const format = quill.getFormat(selection);
+
+  return {
+    font: format.font || null,
+    size: format.size || null,
+    bold: Boolean(format.bold),
+    italic: Boolean(format.italic),
+    color: format.color || null,
+    background: format.background || null,
+    align: format.align || 'left',
+  };
+}
+
+async function persistEditorTemplateState() {
+  const status = await persistEditorTemplateToIndexedDb(getEditorTemplateSnapshot());
+  if (!status?.ok && status?.error) {
+    console.warn('Unable to persist editor template to IndexedDB.', status.error);
+  }
+}
+
+function applyEditorTemplateSnapshot(templateData) {
+  if (!templateData || typeof templateData !== 'object') {
+    return;
+  }
+
+  const selection = quill.getSelection() || lastKnownSelection || { index: 0, length: 0 };
+  const index = Number.isFinite(selection.index) ? selection.index : 0;
+  const length = Number.isFinite(selection.length) ? selection.length : 0;
+
+  isApplyingEditorTemplate = true;
+  quill.setSelection(index, length, 'silent');
+
+  quill.format('font', templateData.font || false, 'silent');
+  quill.format('size', templateData.size || false, 'silent');
+  quill.format('bold', Boolean(templateData.bold), 'silent');
+  quill.format('italic', Boolean(templateData.italic), 'silent');
+  quill.format('color', templateData.color || false, 'silent');
+  quill.format('background', templateData.background || false, 'silent');
+  quill.format('align', templateData.align && templateData.align !== 'left' ? templateData.align : false, 'silent');
+  isApplyingEditorTemplate = false;
+
+  syncFontSizeInputFromSelection();
+}
+
+async function initializeEditorTemplateFromPersistence() {
+  try {
+    const templateData = await restoreEditorTemplateFromIndexedDb();
+    if (!templateData) {
+      await persistEditorTemplateState();
+      return;
+    }
+
+    applyEditorTemplateSnapshot(templateData);
+  } catch (error) {
+    console.warn('Unable to initialize editor template persistence.', error);
+  }
+}
 
 function setFontSizeInputValue(value) {
   if (!fontSizeInput) {
@@ -839,6 +904,14 @@ quill.on('text-change', () => {
   syncFontSizeInputFromSelection();
 });
 
+quill.on('editor-change', () => {
+  if (isApplyingEditorTemplate) {
+    return;
+  }
+
+  void persistEditorTemplateState();
+});
+
 function isTextWrapEnabled() {
   return !wrapTextInput || wrapTextInput.checked;
 }
@@ -1021,6 +1094,7 @@ const manageFontsWindowController = createManageFontsWindowController({
 });
 
 void initializeFontLibraryFromPersistence();
+void initializeEditorTemplateFromPersistence();
 
 function openManageImagesWindow(slotType = null, slotName = null) {
   const initialImageId = slotType && slotName

--- a/src/app.js
+++ b/src/app.js
@@ -678,10 +678,23 @@ function applyEditorTemplateSnapshot(templateData) {
   const selection = quill.getSelection() || lastKnownSelection || { index: 0, length: 0 };
   const index = Number.isFinite(selection.index) ? selection.index : 0;
   const length = Number.isFinite(selection.length) ? selection.length : 0;
+  const contentLength = Math.max(0, quill.getLength() - 1);
+  const lineLength = Math.max(1, quill.getLength());
 
   isApplyingEditorTemplate = true;
-  quill.setSelection(index, length, 'silent');
 
+  if (contentLength > 0) {
+    quill.formatText(0, contentLength, 'font', templateData.font || false, 'silent');
+    quill.formatText(0, contentLength, 'size', templateData.size || false, 'silent');
+    quill.formatText(0, contentLength, 'bold', Boolean(templateData.bold), 'silent');
+    quill.formatText(0, contentLength, 'italic', Boolean(templateData.italic), 'silent');
+    quill.formatText(0, contentLength, 'color', templateData.color || false, 'silent');
+    quill.formatText(0, contentLength, 'background', templateData.background || false, 'silent');
+  }
+
+  quill.formatLine(0, lineLength, 'align', templateData.align && templateData.align !== 'left' ? templateData.align : false, 'silent');
+
+  quill.setSelection(index, length, 'silent');
   quill.format('font', templateData.font || false, 'silent');
   quill.format('size', templateData.size || false, 'silent');
   quill.format('bold', Boolean(templateData.bold), 'silent');
@@ -689,8 +702,8 @@ function applyEditorTemplateSnapshot(templateData) {
   quill.format('color', templateData.color || false, 'silent');
   quill.format('background', templateData.background || false, 'silent');
   quill.format('align', templateData.align && templateData.align !== 'left' ? templateData.align : false, 'silent');
-  isApplyingEditorTemplate = false;
 
+  isApplyingEditorTemplate = false;
   syncFontSizeInputFromSelection();
 }
 

--- a/src/editor/editorTemplatePersistenceIndexedDb.js
+++ b/src/editor/editorTemplatePersistenceIndexedDb.js
@@ -1,0 +1,143 @@
+const DB_NAME = 'textbox-generator-editor-template-library';
+const DB_VERSION = 1;
+const TEMPLATE_STORE = 'templates';
+const TEMPLATE_RECORD_ID = 'editor-template';
+const TEMPLATE_NAME = 'editor template';
+
+const PERSISTENCE_ERROR_REASONS = {
+  QUOTA_EXCEEDED: 'quota-exceeded',
+  UNAVAILABLE: 'unavailable',
+  UNKNOWN: 'unknown',
+};
+
+function createSuccessStatus() {
+  return { ok: true };
+}
+
+function createFailureStatus(reason, error) {
+  return { ok: false, reason, error };
+}
+
+function isQuotaExceededError(error) {
+  if (!error) {
+    return false;
+  }
+
+  const name = String(error.name || '');
+  const code = Number(error.code);
+
+  return name === 'QuotaExceededError'
+    || name === 'NS_ERROR_DOM_QUOTA_REACHED'
+    || code === 22
+    || code === 1014;
+}
+
+function toPersistenceErrorReason(error) {
+  if (isQuotaExceededError(error)) {
+    return PERSISTENCE_ERROR_REASONS.QUOTA_EXCEEDED;
+  }
+
+  if (error?.name === 'InvalidStateError' || error?.name === 'NotSupportedError') {
+    return PERSISTENCE_ERROR_REASONS.UNAVAILABLE;
+  }
+
+  return PERSISTENCE_ERROR_REASONS.UNKNOWN;
+}
+
+function openDatabase(indexedDb = window.indexedDB) {
+  if (!indexedDb || typeof indexedDb.open !== 'function') {
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = indexedDb.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const database = request.result;
+
+      if (!database.objectStoreNames.contains(TEMPLATE_STORE)) {
+        database.createObjectStore(TEMPLATE_STORE, { keyPath: 'id' });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error('Unable to open IndexedDB.'));
+  });
+}
+
+function requestToPromise(request) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error('IndexedDB request failed.'));
+  });
+}
+
+function transactionDone(transaction) {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () => reject(transaction.error || new Error('IndexedDB transaction aborted.'));
+    transaction.onerror = () => reject(transaction.error || new Error('IndexedDB transaction failed.'));
+  });
+}
+
+export async function persistEditorTemplateToIndexedDb(templateData, { indexedDb = window.indexedDB } = {}) {
+  if (!templateData || typeof templateData !== 'object') {
+    return createFailureStatus(PERSISTENCE_ERROR_REASONS.UNAVAILABLE, null);
+  }
+
+  let database = null;
+
+  try {
+    database = await openDatabase(indexedDb);
+    if (!database) {
+      return createFailureStatus(PERSISTENCE_ERROR_REASONS.UNAVAILABLE, null);
+    }
+
+    const transaction = database.transaction([TEMPLATE_STORE], 'readwrite');
+    const templateStore = transaction.objectStore(TEMPLATE_STORE);
+
+    templateStore.put({
+      id: TEMPLATE_RECORD_ID,
+      name: TEMPLATE_NAME,
+      data: templateData,
+      updatedAt: Date.now(),
+    });
+
+    await transactionDone(transaction);
+    return createSuccessStatus();
+  } catch (error) {
+    return createFailureStatus(toPersistenceErrorReason(error), error);
+  } finally {
+    database?.close();
+  }
+}
+
+export async function restoreEditorTemplateFromIndexedDb({ indexedDb = window.indexedDB } = {}) {
+  const database = await openDatabase(indexedDb);
+
+  if (!database) {
+    return null;
+  }
+
+  try {
+    const transaction = database.transaction([TEMPLATE_STORE], 'readonly');
+    const templateStore = transaction.objectStore(TEMPLATE_STORE);
+    const templateRecord = await requestToPromise(templateStore.get(TEMPLATE_RECORD_ID));
+
+    return templateRecord?.data || null;
+  } finally {
+    database.close();
+  }
+}
+
+export const editorTemplateIndexedDbConfig = {
+  databaseName: DB_NAME,
+  version: DB_VERSION,
+  stores: {
+    templates: TEMPLATE_STORE,
+  },
+  template: {
+    id: TEMPLATE_RECORD_ID,
+    name: TEMPLATE_NAME,
+  },
+};

--- a/tests/unit/editorTemplatePersistenceIndexedDb.test.js
+++ b/tests/unit/editorTemplatePersistenceIndexedDb.test.js
@@ -139,6 +139,8 @@ describe('indexeddb editor template persistence', () => {
       color: '#112233',
       background: '#fef3c7',
       align: 'center',
+      wrapText: false,
+      maxImageWidth: '720',
     };
 
     const persistStatus = await persistEditorTemplateToIndexedDb(snapshot, { indexedDb });

--- a/tests/unit/editorTemplatePersistenceIndexedDb.test.js
+++ b/tests/unit/editorTemplatePersistenceIndexedDb.test.js
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  persistEditorTemplateToIndexedDb,
+  restoreEditorTemplateFromIndexedDb,
+} from '../../src/editor/editorTemplatePersistenceIndexedDb.js';
+
+function createFakeIndexedDb() {
+  const databases = new Map();
+
+  function createDatabase(name) {
+    if (!databases.has(name)) {
+      databases.set(name, { stores: new Map() });
+    }
+
+    const state = databases.get(name);
+
+    return {
+      objectStoreNames: {
+        contains(storeName) {
+          return state.stores.has(storeName);
+        },
+      },
+      createObjectStore(storeName) {
+        if (!state.stores.has(storeName)) {
+          state.stores.set(storeName, new Map());
+        }
+
+        return { name: storeName };
+      },
+      transaction(storeNames) {
+        const names = Array.isArray(storeNames) ? storeNames : [storeNames];
+        let pending = 0;
+        const listeners = { oncomplete: null, onerror: null, onabort: null };
+
+        function tryComplete() {
+          if (pending === 0 && typeof listeners.oncomplete === 'function') {
+            setTimeout(() => listeners.oncomplete(), 0);
+          }
+        }
+
+        const transaction = {
+          error: null,
+          get oncomplete() { return listeners.oncomplete; },
+          set oncomplete(handler) { listeners.oncomplete = handler; tryComplete(); },
+          get onerror() { return listeners.onerror; },
+          set onerror(handler) { listeners.onerror = handler; },
+          get onabort() { return listeners.onabort; },
+          set onabort(handler) { listeners.onabort = handler; },
+          objectStore(storeName) {
+            if (!names.includes(storeName)) {
+              throw new Error(`Store ${storeName} not in transaction.`);
+            }
+
+            if (!state.stores.has(storeName)) {
+              state.stores.set(storeName, new Map());
+            }
+
+            const backingStore = state.stores.get(storeName);
+
+            function makeRequest(action) {
+              pending += 1;
+              const request = { onsuccess: null, onerror: null, result: undefined, error: null };
+
+              setTimeout(() => {
+                try {
+                  request.result = action();
+                  request.onsuccess?.();
+                } catch (error) {
+                  request.error = error;
+                  request.onerror?.();
+                } finally {
+                  pending -= 1;
+                  tryComplete();
+                }
+              }, 0);
+
+              return request;
+            }
+
+            return {
+              put(value) {
+                return makeRequest(() => {
+                  backingStore.set(value.id, value);
+                  return value.id;
+                });
+              },
+              get(key) {
+                return makeRequest(() => backingStore.get(key));
+              },
+            };
+          },
+        };
+
+        setTimeout(tryComplete, 0);
+        return transaction;
+      },
+      close() {},
+    };
+  }
+
+  return {
+    open(name) {
+      const request = {
+        onupgradeneeded: null,
+        onsuccess: null,
+        onerror: null,
+        result: null,
+        error: null,
+      };
+
+      setTimeout(() => {
+        try {
+          const isNew = !databases.has(name);
+          request.result = createDatabase(name);
+          if (isNew) {
+            request.onupgradeneeded?.();
+          }
+          request.onsuccess?.();
+        } catch (error) {
+          request.error = error;
+          request.onerror?.();
+        }
+      }, 0);
+
+      return request;
+    },
+  };
+}
+
+describe('indexeddb editor template persistence', () => {
+  it('persists and restores the editor template snapshot', async () => {
+    const indexedDb = createFakeIndexedDb();
+    const snapshot = {
+      font: 'arial',
+      size: '18px',
+      bold: true,
+      italic: false,
+      color: '#112233',
+      background: '#fef3c7',
+      align: 'center',
+    };
+
+    const persistStatus = await persistEditorTemplateToIndexedDb(snapshot, { indexedDb });
+    expect(persistStatus).toMatchObject({ ok: true });
+
+    const restored = await restoreEditorTemplateFromIndexedDb({ indexedDb });
+    expect(restored).toEqual(snapshot);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide persistent storage for the editor's current formatting (font, size, bold/italic, text/background color, alignment) so the editor state can be reused as a template across sessions.
- Treat the editor template similarly to existing border templates by storing it in IndexedDB to survive reloads and device restarts.

### Description
- Add a new persistence module `src/editor/editorTemplatePersistenceIndexedDb.js` that implements `persistEditorTemplateToIndexedDb`, `restoreEditorTemplateFromIndexedDb`, and `editorTemplateIndexedDbConfig` for storing a single `editor-template` record.
- Wire persistence into the app in `src/app.js` by importing the new helpers, adding `getEditorTemplateSnapshot` to capture current formats, `persistEditorTemplateState` to save snapshots, and `applyEditorTemplateSnapshot` / `initializeEditorTemplateFromPersistence` to restore on startup.
- Persist the snapshot on editor changes by listening for `editor-change` and guard against feedback loops with the `isApplyingEditorTemplate` flag.
- Add unit test `tests/unit/editorTemplatePersistenceIndexedDb.test.js` that verifies a round-trip persist/restore against a fake IndexedDB implementation.

### Testing
- Ran unit tests with `npm run test:unit`, and all unit tests passed (17 test files, 82 tests passed). 
- The new editor template unit test `tests/unit/editorTemplatePersistenceIndexedDb.test.js` executed and passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5af1c95588326b780277cb25493f8)